### PR TITLE
Fixed URL for vue-formidable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@
   - [vue-html-editor](https://github.com/Haixing-Hu/vue-html-editor): A Vue.js component implementing the HTML editor with the [jQuery summernote plugin](https://github.com/summernote/summernote). By @Haixing-Hu
   - [vue-datetime-picker](https://github.com/Haixing-Hu/vue-datetime-picker): A Vue.js component implementing the datetime picker control using the [Eonasdan's bootstrap datetime picker plugin](https://github.com/Eonasdan/bootstrap-datetimepicker). By @Haixing-Hu
   - [vue-country-select](https://github.com/Haixing-Hu/vue-country-select): A Vue.js component implementing the select control used to select countries. It depends on [vue-select](https://github.com/Haixing-Hu/vue-select) and [vue-i18n](https://github.com/Haixing-Hu/vue-i18n). By @Haixing-Hu
-  - [Form generation from JSON Schema](https://github.com/dgerber/vue-select-js) by @dgerber
+  - [Form generation from JSON Schema](https://github.com/dgerber/vue-formidable) by @dgerber
   - [vue-panel](https://github.com/ericmcdaniel/vue-panel): A suite of Vue.js components for building Flexbox layouts by @ericmcdaniel
 
 - #### i18n


### PR DESCRIPTION
The link for `vue-formidable` (listed as "Form generation from JSON Schema") was incorrect; it pointed to `vue-select-js` instead.