### PR TITLE
Update 1.0 compat tag on vue-validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@
 
 - #### Validation
 
-  - [vue-validator](https://github.com/vuejs/vue-validator) - Form validation plugin maintained by @kazupon <sup>0.12</sup>
+  - [vue-validator](https://github.com/vuejs/vue-validator) - Form validation plugin maintained by @kazupon <sup>1.0 compatible</sup>
   - [Vue validator](https://github.com/xrado/vue-validator) by @xrado
   - [vue-form](https://github.com/fergaldoyle/vue-form) by @fergaldoyle <sup>1.0 compatible</sup>
 


### PR DESCRIPTION
I noticed the requirements on vue-validator are 1.0.14+ now.