### PR TITLE
Add stars count and last pushed date for GitHub repos

### DIFF
--- a/awesome_vue_with_repo_info.md
+++ b/awesome_vue_with_repo_info.md
@@ -1,0 +1,356 @@
+<img src="https://rawgit.com/vuejs/awesome-vue/master/logo.png" alt="awesome" width="400" />
+
+Awesome Vue.js [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+> A curated list of awesome things related to Vue.js
+
+-   [Official Resources](#official-resources)
+-   [External Resources](#external-resources)
+-   [Community](#community)
+-   [Podcasts](#podcasts)
+-   [Official Examples](#official-examples)
+-   [Tutorials](#tutorials)
+-   [Development Tools](#development-tools)
+-   [Syntax Highlighting](#syntax-highlighting)
+-   [Snippets](#snippets)
+-   [Libraries & Plugins](#libraries--plugins)
+    -   [Routing](#routing)
+    -   [Ajax/Data](#ajaxdata)
+    -   [State Management](#state-management)
+    -   [Validation](#validation)
+    -   [UI Components](#ui-components)
+    -   [i18n](#i18n)
+    -   [Examples](#examples)
+    -   [Boilerplates](#boilerplates)
+    -   [Scaffolding](#scaffolding)
+    -   [Integrations](#integrations)
+    -   [General Plugins/Directives](#general-pluginsdirectives)
+-   [Projects Using Vue.js](#projects-using-vuejs)
+    -   [Open Source](#open-source)
+    -   [Apps/Websites](#appswebsites)
+    -   [Interactive Experiences](#interactive-experiences)
+    -   [Enterprise Usage](#enterprise-usage)
+
+### Official Resources
+
+-   [Official Guide](http://vuejs.org/guide/)
+-   [API Reference](http://vuejs.org/api/)
+-   [GitHub Repo](https://github.com/vuejs/vue) <span> | ★ 16753, pushed 0 days ago | </span>
+-   [Release Notes](https://github.com/vuejs/vue/releases)
+
+### External Resources
+
+-   [Vue.js資料まとめ(for japanese)](https://gist.github.com/hashrock/f575928d0e109ace9ad0) by @hashrock
+
+### Community
+
+-   [Twitter](https://twitter.com/vuejs)
+-   [Gitter Chat Room](https://gitter.im/vuejs/vue)
+-   [Official Forum](http://forum.vuejs.org/)
+-   [vue-requests](https://github.com/simplesmiler/vue-requests) - Request a Vue.js module you wish existed or get ideas for modules
+
+### Podcasts
+
+-   [Full Stack Radio \#30 (11-23-2015)](http://www.fullstackradio.com/30)
+-   [JavaScript Jabber \#187 (11-25-2015)](https://devchat.tv/js-jabber/187-jsj-vue-js-with-evan-you)
+-   [Changelog \#184 (11-27-2015)](https://changelog.com/184/)
+-   [Software Engineering Daily (12-29-2015)](http://softwareengineeringdaily.com/2015/12/29/front-end-javascript-with-evan-you/)
+-   [Javascript Air 016 (03-30-2016)](https://javascriptair.com/episodes/2016-03-30/)
+
+### Official Examples
+
+-   [Basic Examples](http://vuejs.org/guide/)
+-   [Vue.js TodoMVC](https://github.com/vuejs/vue/tree/dev/examples/todomvc)
+    -   [CoffeeScript Version](https://github.com/anfelor/TodoMVC-CoffeeScript-and-Vue.js) <span> | ★ 3, pushed 51 days ago | </span>
+-   [Vue.js HackerNews Clone](https://github.com/vuejs/vue-hackernews) <span> | ★ 891, pushed 55 days ago | </span>
+
+### Tutorials
+
+-   [Vue.js screencasts](https://laracasts.com/series/learning-vue-step-by-step) on Laracasts
+-   [What's New in Vue.js 1.0](http://www.sitepoint.com/whats-new-in-vue-js-1-0/) on Sitepoint
+-   [Build an App with Vue.js: From Authentication to Calling an API](https://auth0.com/blog/2015/11/13/build-an-app-with-vuejs/) on Auth0 blog
+-   [Create a GitHub File Explorer Using Vue.js](https://scotch.io/tutorials/create-a-github-file-explorer-using-vue-js) on Scotch.io
+-   [Vue.js Tutorial](http://vegibit.com/vue-js-tutorial/) on Vegibit
+-   [Vue.js build set-up from scratch with webpack, vue-loader and hot reload](http://skyronic.com/2015/12/28/vue-project-scratch/)
+-   [Vuex basics: Tutorial and explanation](http://skyronic.com/2016/01/03/vuex-basics-tutorial/)
+-   [Vuex introduction video - James Browne from London Vue.js Meetup \#1](https://www.youtube.com/watch?v=l1KHL-TX3qs)
+-   [Vue.js 中文系列视频教程](https://laravist.com/series/vue-js-1-0-in-action-series) on Laravist
+-   [Vue.js: The Basics](http://coligo.io/vuejs-the-basics/) on Coligo.io
+-   [Practical Intro to Components in Vue.js](http://coligo.io/vuejs-components) on Coligo.io
+-   [Develop a Reactive Invoice App using Vue.js](http://craigmckenna.com/develop-a-reactive-invoice-app-using-vue-js/) on craigmckenna.com
+-   [Understanding Filters in Vue.js](http://coligo.io/vuejs-filters/) on Coligo.io
+-   [Hybrid App Example with Laravel and Vue.js in portuguese](https://www.youtube.com/watch?v=TGSJjDahlrQ) by @vedovelli
+-   [Creating a Markdown Editor with VueJs and GitHub's API](http://coligo.io/markdown-editor-vuejs/) on Coligo.io
+-   [Building a Real-Time Web Analytics Dashboard with NodeJs, Socket.io, and VueJs](http://coligo.io/real-time-analytics-with-nodejs-socketio-vuejs/) on Coligo.io
+-   [Vue.js Introduction Turkish Language](http://oguzhan.in/vue-js-ile-uygulama-gelistirme/) on oguzhan.in
+-   [Vue.js VideoTutoral Series in Spanish (3-8-2016)](https://www.youtube.com/watch?v=IlFk3cyRB0Y&list=PLM-Y_YQmMEqD2EWfWpSbiV3WgShRRW3FE&index=7) on YouTube by Juan Andrés Núñez
+-   [Building a Bookmarking App with Electron, VueJs, and Firebase](http://coligo.io/bookmarking-app-electron-vuejs-firebase/) on Coligo.io
+
+#### 0.12 and earlier
+
+-   [Vue.js screencasts](https://laracasts.com/series/learning-vuejs) on Laracasts <sup>0.12</sup>
+-   [Build an App with Vue.js](https://scotch.io/tutorials/build-an-app-with-vue-js-a-lightweight-alternative-to-angularjs) on Scotch.io <sup>0.12</sup>
+-   [Getting Started with Vue.js](http://www.sitepoint.com/getting-started-with-vue-js/) on Sitepoint <sup>0.12</sup>
+-   [Vue.js video series in portuguese](http://forum.vuejs.org/topic/49/vue-js-video-series-in-portuguese) <sup>0.12</sup>
+-   [Vue.js video series in russian](http://ausite.ru/category/js/vue-js) on Ausite <sup>0.12</sup>
+-   [A Quick Introduction to Vue.js](http://mattsparks.com/a-quick-introduction-to-vue-js/) by Matt Sparks <sup>0.12</sup>
+-   [Getting Started with Vue.js + vue-router](https://www.youtube.com/watch?v=QN7l3ydXvx0) by Michael Calkins <sup>0.12</sup>
+-   [Many JS Frameworks but Vue.js Is Different](http://taha-sh.com/blog/many-js-frameworks-but-vuejs-is-different) by Taha Shashtari <sup>0.12</sup>
+-   [Getting Started with Vue.js - AngularJS perspective](http://fadeit.dk/blog/post/getting-started-with-vuejs-angularjs-perspective) by Dan Mindru <sup>0.11</sup>
+
+### Development Tools
+
+-   [vue-cli](https://github.com/vuejs/vue-cli) <span> | ★ 561, pushed 9 days ago | </span> : official CLI for scaffolding Vue.js projects.
+-   [vue-loader](https://github.com/vuejs/vue-loader) <span> | ★ 448, pushed 0 days ago | </span> - Vue component loader for Webpack.
+    -   [vue-loader-example](https://github.com/vuejs/vue-loader-example) <span> | ★ 312, pushed 47 days ago | </span>
+-   [vueify](https://github.com/vuejs/vueify) <span> | ★ 405, pushed 2 days ago | </span> - Vue compcomponent transform for Browserify.
+    -   [vueify-example](https://github.com/vuejs/vueify-example) <span> | ★ 83, pushed 82 days ago | </span>
+-   [vue-devtools](https://github.com/vuejs/vue-devtools) <span> | ★ 580, pushed 9 days ago | </span> - Chrome devtools extension for debugging Vue applications.
+-   [grunt-vueify](https://github.com/SkewedAspect/grunt-vueify) <span> | ★ 1, pushed 53 days ago | </span> - Translate `    .vue   ` files to pure JavaScript, without using Browserify. (Useful for Electron apps)
+-   [vue-compiler](https://github.com/paulpflug/vue-compiler) <span> | ★ 2, pushed 6 days ago | </span> - A simple CLI wrapper around vueify
+-   [vue-autocompile](https://atom.io/packages/vue-autocompile) - Atom.io package to compile `    .vue   ` files on save.
+-   [vue-dev-server](https://github.com/paulpflug/vue-dev-server) <span> | ★ 3, pushed 41 days ago | </span> - A small webpack-based development server for building standalone `    vue   ` components
+-   [vue-go-cli](https://github.com/rodzzlessa24/vue-go-cli) <span> | ★ 2, pushed 47 days ago | </span> - a CLI tool for scaffolding new projects generating components, services, and mixins.
+-   [brunch-vue](https://github.com/nblackburn/vue-brunch) <span> | ★ 2, pushed 43 days ago | </span> - Adds support to Brunch for pre-compiling single file Vue components.
+-   [vueify-extract-css](https://github.com/rawcreative/vueify-extract-css) <span> | ★ 18, pushed 28 days ago | </span> - Browserify plugin to extract css from Vueify-compiled single file components to a separate css file.
+-   [eslint-plugin-vue](https://github.com/twiknight/eslint-plugin-vue) <span> | ★ 19, pushed 20 days ago | </span> - Eslint plugin for .vue files.
+
+### Syntax Highlighting
+
+-   [Sublime Text](https://github.com/vuejs/vue-syntax-highlight) <span> | ★ 162, pushed 10 days ago | </span>
+-   [Atom](https://atom.io/packages/language-vue) by @hedefalk
+-   [Atom (2)](https://atom.io/packages/language-vue-component) by @CYBAI
+-   [Vim](https://github.com/posva/vim-vue) <span> | ★ 30, pushed 1 days ago | </span> by @darthmall and @posva
+-   [Visual Studio Code](https://marketplace.visualstudio.com/items/liuji-jim.vue) by Jim Liu
+-   [Brackets](https://github.com/pandao/brackets-vue) <span> | ★ 6, pushed 112 days ago | </span> by @pandao
+-   [IntelliJ IDEA / WebStorm](https://github.com/henjue/vue-for-idea) <span> | ★ 134, pushed 27 days ago | </span> by @henjue
+-   [Emacs](https://github.com/CodeFalling/vue-mode) <span> | ★ 2, pushed 8 days ago | </span> by @CodeFalling
+
+### Snippets
+
+-   [vue-snippets](https://atom.io/packages/vue-snippets) for Atom.io by [@ealves-pt](https://github.com/ealves-pt)
+
+### Libraries & Plugins
+
+-   \#\#\#\# Routing
+
+    -   [vue-router](https://github.com/vuejs/vue-router) <span> | ★ 1063, pushed 0 days ago | </span> - Official router for building SPAs. <sup>1.0\\ compatible</sup>
+    -   [Vue page](https://github.com/AlexToudic/vue-page) <span> | ★ 15, pushed 246 days ago | </span> , a routing system based on pagejs by @AlexToudic
+    -   [Vue Lanes](https://github.com/bpierre/vue-lanes) <span> | ★ 19, pushed 755 days ago | </span> , an event-based routing system for Vue by @bpierre
+    -   [Vue route](https://github.com/ayamflow/vue-route) <span> | ★ 70, pushed 257 days ago | </span> , ng-view inspired routes for Vue by @ayamflow
+    -   [voie](https://github.com/inca/voie) <span> | ★ 107, pushed 1 days ago | </span> — simple router / layout manager inspired by FSMs and ui-router by [Boris Okunskiy](https://github.com/inca) <sup>1.0</sup>
+-   \#\#\#\# Ajax/Data
+
+    -   [vue-resource](https://github.com/vuejs/vue-resource) <span> | ★ 1136, pushed 33 days ago | </span> - AJAX/Resource plugin maintained by the [PageKit](http://pagekit.com/) team. <sup>1.0\\ compatible</sup>
+    -   [vue-async-data](https://github.com/vuejs/vue-async-data) <span> | ★ 174, pushed 1 days ago | </span> - Async data loading plugin <sup>1.0\\ compatible</sup>
+    -   [vue-async-computed](https://github.com/foxbenjaminfox/vue-async-computed) <span> | ★ 15, pushed 2 days ago | </span> - Plugin to support computed properties that are calculated asynchronously. By [@foxbenjaminfox](https://github.com/foxbenjaminfox)
+-   \#\#\#\# State Management
+
+    -   [vuex](https://github.com/vuejs/vuex) <span> | ★ 1174, pushed 0 days ago | </span> - Flux/Redux inspired application architecture for Vue.js.
+    -   [revue](https://github.com/egoist/revue) - Redux binding for Vue by @egoist
+    -   [vue-redux](https://github.com/yang-wei/vue-redux) <span> | ★ 74, pushed 74 days ago | </span> - Redux binding for Vue by @yang-wei
+    -   [vue-freeze](https://github.com/BosNaufal/vue-freeze) <span> | ★ 28, pushed 20 days ago | </span> - Simple state management whitout bloating API and Concept for Vue by [@BosNaufal](https://github.com/BosNaufal)
+    -   [vue-simple-store](https://github.com/BosNaufal/vue-simple-store) <span> | ★ 24, pushed 21 days ago | </span> - Store Organizer To Simplify Your Stores for Vue By [@BosNaufal](https://github.com/BosNaufal)
+-   \#\#\#\# Validation
+
+    -   [vue-validator](https://github.com/vuejs/vue-validator) <span> | ★ 531, pushed 0 days ago | </span> - Form validation plugin maintained by @kazupon <sup>1.0\\ compatible</sup>
+    -   [Vue validator](https://github.com/xrado/vue-validator) <span> | ★ 34, pushed 194 days ago | </span> by @xrado
+    -   [vue-form](https://github.com/fergaldoyle/vue-form) <span> | ★ 105, pushed 1 days ago | </span> by @fergaldoyle <sup>1.0\\ compatible</sup>
+-   \#\#\#\# UI Components
+
+    -   [VueStrap](http://yuche.github.io/vue-strap/) , Bootstrap components built with pure Vue.js by @yuche <sup>1.0</sup>
+    -   [VueBoot](http://morgul.github.io/vueboot/) , Bootstrap v4 components by @Morgul <sup>1.0</sup>
+    -   [vue-mdl](https://github.com/posva/vue-mdl) <span> | ★ 280, pushed 3 days ago | </span> : Reusable Vue.js components using Material Design Lite. By [@posva](https://github.com/posva)
+    -   [vue-countup](https://github.com/samcrosoft/vue-countup) <span> | ★ 8, pushed 77 days ago | </span> : A Vue.js component for the very interesting [CountUp.js](https://inorganik.github.io/countUp.js/) plugin. <sup>1.0\\ compatible</sup>
+    -   [Vue Tag Editor Component](https://github.com/hnakamur/vue.tag-editor.js) <span> | ★ 19, pushed 761 days ago | </span> by @hnakamur
+    -   [Vue Crop](http://pespantelis.github.io/vue-crop/)
+    -   [Vue Typeahead](http://pespantelis.github.io/vue-typeahead/)
+    -   [Typed select component](https://github.com/dgerber/vue-select-js) <span> | ★ 3, pushed 320 days ago | </span> by @dgerber
+    -   [vue-select](https://github.com/Haixing-Hu/vue-select) <span> | ★ 44, pushed 42 days ago | </span> : A Vue.js component implementing the select control with the [jQuery select2 plugin](https://github.com/select2/select2) . By @Haixing-Hu
+    -   [vue-html-editor](https://github.com/Haixing-Hu/vue-html-editor) <span> | ★ 54, pushed 78 days ago | </span> : A Vue.js component implementing the HTML editor with the [jQuery summernote plugin](https://github.com/summernote/summernote) . By @Haixing-Hu
+    -   [vue-datetime-picker](https://github.com/Haixing-Hu/vue-datetime-picker) <span> | ★ 53, pushed 16 days ago | </span> : A Vue.js component implementing the datetime picker control using the [Eonasdan's bootstrap datetime picker plugin](https://github.com/Eonasdan/bootstrap-datetimepicker) . By @Haixing-Hu
+    -   [vue-country-select](https://github.com/Haixing-Hu/vue-country-select) <span> | ★ 11, pushed 191 days ago | </span> : A Vue.js component implementing the select control used to select countries. It depends on [vue-select](https://github.com/Haixing-Hu/vue-select) and [vue-i18n](https://github.com/Haixing-Hu/vue-i18n) . By @Haixing-Hu
+    -   [Form generation from JSON Schema](https://github.com/dgerber/vue-formidable) <span> | ★ 19, pushed 319 days ago | </span> by @dgerber
+    -   [vue-panel](https://github.com/ericmcdaniel/vue-panel) <span> | ★ 36, pushed 111 days ago | </span> : A suite of Vue.js components for building Flexbox layouts by @ericmcdaniel
+    -   [vue-google-maps](https://github.com/GuillaumeLeclerc/vue-google-maps/) : A suite of Vue.js components to build reactive Google Maps Applications by @GuillaumeLeclerc
+    -   [vue-transition](https://github.com/Twiknight/vue-transition) <span> | ★ 33, pushed 48 days ago | </span> : A component to trigger a CSS transition at any time by @Twiknight
+    -   [SVG icons](http://kzima.github.io/vuestrap-icons/#/icons) , SVG sprites in form of a simple `           ` component, by @kzima <sup>1.0</sup>
+    -   [Extra Vuestrap components](http://gritcode.github.io/gritcode-components/#/toast) , more components built with just B4 and Vue.js, by @kzima <sup>1.0</sup>
+    -   [VueStrap Base Components](http://kzima.github.io/vuestrap-base-components/#/accordion) , A complete set of Bootstrap 4 web components built with pure Vue.js, by @kzima <sup>1.0</sup>
+    -   [Vue YouTube Embed](https://github.com/kaorun343/vue-youtube-embed) <span> | ★ 16, pushed 28 days ago | </span> : a directive for Vue.js and YouTube by @kaorun343
+    -   [Vue datepicker](https://github.com/hilongjw/vue-datepicker) <span> | ★ 48, pushed 0 days ago | </span> : calendar and datepicker component with material design for Vue.js by @hilongjw
+    -   [vue-date-picker](https://github.com/Bubblings/vue-date-picker) <span> | ★ 15, pushed 7 days ago | </span> : A simple datepicker component for Vue.js by @Bubblings
+    -   [vue-spinner](https://github.com/greyby/vue-spinner) <span> | ★ 128, pushed 53 days ago | </span> : A collection of loading spinners with Vue.js.
+    -   [vue-image-loader](https://github.com/eduardostuart/vue-image-loader) <span> | ★ 13, pushed 72 days ago | </span> : Async image loader for Vue.js by @eduardostuart
+    -   [Vue-progressbar](https://github.com/hilongjw/vue-progressbar) <span> | ★ 35, pushed 72 days ago | </span> : A lightweight progress bar for Vue.js by @hilongjw
+    -   [Famous-Vue](https://github.com/irwansyahwii/Famous-Vue) <span> | ★ 10, pushed 63 days ago | </span> : Declarative Famous using Vue
+    -   [vue-waterfall](https://github.com/MopTym/vue-waterfall) <span> | ★ 197, pushed 53 days ago | </span> : A waterfall layout component for Vue.js by @MopTym
+    -   [vue-charts](https://github.com/haydenbbickerton/vue-charts) <span> | ★ 17, pushed 14 days ago | </span> : A Google Charts plugin for Vue.js by [@haydenbbickerton](https://github.com/haydenbbickerton)
+    -   [vux](https://github.com/airyland/vux) <span> | ★ 1046, pushed 0 days ago | </span> : Mobile web UI Components based on Vue and WeUI
+    -   [vue-select](https://github.com/sagalbot/vue-select) <span> | ★ 154, pushed 7 days ago | </span> : Simple component that implements Select2/Chosen style dropdowns with no dependencies <sup>1.0</sup>
+    -   [Vue-slide](https://github.com/hilongjw/vue-slide) <span> | ★ 27, pushed 18 days ago | </span> : A lightweight slide component for Vue.js by @hilongjw
+    -   [Vue-quill](https://github.com/CroudSupport/vue-quill) <span> | ★ 5, pushed 21 days ago | </span> : A Vue component implementing the [Quill](https://github.com/quilljs/quill.git) text editor by @brockreece
+    -   [vue-pagenav](https://github.com/zxdong262/vue-pagenav) <span> | ★ 6, pushed 3 days ago | </span> : A vue pagenav plugin by [@zxdong262](https://github.com/zxdong262)
+    -   [Vue-calendar](https://github.com/cucygh/vue-calendar) <span> | ★ 1, pushed 22 days ago | </span> : A vue calendar component with less code by cucygh
+    -   [Vue Material Components](http://appcomponents.org/material-components/) : Vue.js UI components using [materializecss.com](http://materializecss.com/) by mjanys
+    -   [vue-autocomplete](https://github.com/BosNaufal/vue-autocomplete) <span> | ★ 21, pushed 93 days ago | </span> Autocomplete Component for Vue by [@BosNaufal](https://github.com/BosNaufal)
+    -   [vue-loading-bar](https://github.com/BosNaufal/vue-loading-bar) <span> | ★ 25, pushed 9 days ago | </span> Youtube Like Loading Bar Component for Vue by [@BosNaufal](https://github.com/BosNaufal)
+    -   [vue-bootstrap-modal](https://github.com/Coffcer/vue-bootstrap-modal) <span> | ★ 5, pushed 2 days ago | </span> Bootstrap style modal component for Vue by [@Coffcer](https://github.com/Coffcer)
+    -   [vue-comps](https://github.com/vue-comps) : A collection of unstyled and unanimated components (side-nav / modal / collapsible / clusterize / dropdown / resize-handle and other)
+    -   [vue-materialize](https://github.com/paulpflug/vue-materialize) <span> | ★ 20, pushed 0 days ago | </span> : materializeCss styles and animations for some of [vue-comps](https://github.com/vue-comps)
+    -   [vue-waves](https://github.com/Teddy-Zhu/vue-waves) <span> | ★ 3, pushed 7 days ago | </span> :Click effect inspired by Google's Material Design ,the vue version By @Teddy-Zhu
+    -   [vue-table](https://github.com/ratiw/vue-table) <span> | ★ 24, pushed 2 days ago | </span> : component that will automatically request (JSON) data from the server and display them nicely in html table with swappable/extensible pagination component. By @ratiw
+    -   [fire-select](https://github.com/firework/fire-select) <span> | ★ 20, pushed 0 days ago | </span> : Vue component that transforms overwhelming select boxes into something fancy, simple and user-friendly. It is similar to Selectize, Chosen, Select2, etc.
+-   \#\#\#\# i18n
+
+    -   [vue-i18n](https://github.com/kazupon/vue-i18n) <span> | ★ 163, pushed 0 days ago | </span> : Internationalization plugin.
+    -   [vue-i18n](https://github.com/Haixing-Hu/vue-i18n) <span> | ★ 32, pushed 1 days ago | </span> : A plugin providing a global interface used to localize internationalized messages used in the
+    -   [vue-locale](https://github.com/sebastian-software/vue-locale) <span> | ★ 9, pushed 33 days ago | </span> : Advanced localization support for VueJS
+    -   [vue-jade-editor](https://github.com/zxdong262/vue-jade-editor) <span> | ★ 0, pushed 7 days ago | </span> : a online jade(pug) editor plugin by [@zxdong262](https://github.com/zxdong262)
+-   \#\#\#\# Examples
+
+    -   [Starter Application with JWT Auth + sample backend API in Laravel](http://forum.vuejs.org/topic/39/starter-application-with-jwt-auth-sample-backend-api)
+    -   [Node Webkit + Vue example](https://github.com/brandonjpierce/node-webkit-boilerplate) <span> | ★ 34, pushed 286 days ago | </span> by @brandonjpierce
+    -   [Vue Samples](https://github.com/superlloyd/VueSamples) <span> | ★ 18, pushed 174 days ago | </span> by @superlloyd
+    -   [HackerNews clone with vue.js + vue-router](https://github.com/kazupon/vue-router-hackernews) <span> | ★ 2, pushed 239 days ago | </span> by @kazupon
+    -   [Electron + Vue example](https://github.com/bradstewart/electron-boilerplate-vue) <span> | ★ 141, pushed 0 days ago | </span> by @bradstewart
+    -   [Single page application example (Vue + Voie)](https://github.com/inca/voie-example) <span> | ★ 30, pushed 107 days ago | </span> by [Boris Okunskiy](https://github.com/inca)
+    -   [Begin - Task Manager SPA written in Vue + Lumen](https://github.com/rajabishek/begin) <span> | ★ 10, pushed 24 days ago | </span> by [Raj Abishek](https://github.com/rajabishek)
+    -   [Vue Mini Shop](https://github.com/BosNaufal/vue-mini-shop) <span> | ★ 10, pushed 21 days ago | </span> by [BosNaufal](https://github.com/BosNaufal)
+    -   [Vue SoundCloud](https://github.com/mul14/vue-soundcloud) <span> | ★ 11, pushed 18 days ago | </span> by [mul14](https://github.com/mul14)
+-   \#\#\#\# Boilerplates
+
+    -   [Boilerplate for Vue.js plugin](https://github.com/kazupon/vue-plugin-boilerplate) <span> | ★ 16, pushed 51 days ago | </span> by @kazupon
+    -   [Boilerplate for Vue.js & Atom Electron](https://github.com/rodzzlessa24/vue-electron) <span> | ★ 33, pushed 13 days ago | </span> by @rodzzlessa24
+-   \#\#\#\# Scaffolding
+
+    -   [vue-cli](https://github.com/vuejs/vue-cli) : official CLI for scaffolding Vue.js projects.
+    -   [Vue generator](https://github.com/BirdEggegg/generator-vue) : a simple yeoman generator for Vue by @BirdEggegg
+    -   [VENM stack yeoman generator](https://github.com/jfelsinger/generator-venm) <span> | ★ 35, pushed 119 days ago | </span> by @jfelsinger
+    -   [Grail Yeoman Generator](https://github.com/mustardamus/generator-grail) <span> | ★ 9, pushed 166 days ago | </span> : a advanced yeoman generator for a modern modular one page web app, extendable with Vue.js alongside other nice tools
+    -   [VuePack](https://github.com/egoist/vuepack) <span> | ★ 157, pushed 5 days ago | </span> : A modern starter for Vue and Webpack by @egoist
+    -   [VueWebgulp](https://github.com/rodzzlessa24/vue-webgulp) <span> | ★ 31, pushed 29 days ago | </span> : A skeleton app using Vuejs, Gulp, and Webpack by @rodzzlessa24
+    -   [Vuetober](https://github.com/scottbedard/oc-vuetober-theme) <span> | ★ 21, pushed 25 days ago | </span> : SPA scaffolding for October CMS
+    -   [vue-go-cli](https://github.com/rodzzlessa24/vue-go-cli) - a CLI tool for scaffolding new projects generating components, services, and mixins.
+    -   [Brunch with Vue](https://github.com/nblackburn/brunch-with-vue) <span> | ★ 9, pushed 36 days ago | </span> - A skeleton application utilizing vue, vuex, vue-resource and vue-router.
+-   \#\#\#\# Integrations
+
+    -   [Vue for Meteor](https://github.com/zhouzhuojie/meteor-vue) <span> | ★ 74, pushed 113 days ago | </span> by @zhouzhuojie
+    -   [ScalaJS bindings for Vue.js](https://github.com/fancellu/scalajs-vue) <span> | ★ 22, pushed 176 days ago | </span> by @fancellu
+    -   [Socketize Backend](https://github.com/Socketize/vue.js-plugin) <span> | ★ 6, pushed 117 days ago | </span> : Sync your model data to Socketize backend automatically. By [@Socketize](https://github.com/Socketize)
+    -   [Vue-Meteor-Data](https://github.com/Grottolabs/vue-meteor-data) <span> | ★ 12, pushed 2 days ago | </span> Two-way-reactivity mixin for Vue and Meteor by @JakobRosenberg
+    -   [Vue Proerty Decorator](https://github.com/kaorun343/vue-property-decorator) <span> | ★ 7, pushed 86 days ago | </span> : Property Decorators for Vue.js by @kaorun343
+-   \#\#\#\# General Plugins/Directives
+
+    -   [vue-element](https://github.com/vuejs/vue-element) <span> | ★ 72, pushed 325 days ago | </span> : Register real custom elements with Vue.
+    -   [vue-touch](https://github.com/vuejs/vue-touch) <span> | ★ 217, pushed 14 days ago | </span> : Hammer.js wrapper directives for touch gestures. (Updated for 1.0!)
+    -   [vue-animated-list](https://github.com/vuejs/vue-animated-list) <span> | ★ 85, pushed 62 days ago | </span> : A Vue.js plugin for easily animating `      v-for     ` rendered lists.
+    -   [Vue placeholder directives](https://github.com/lithiumjake/vue-placeholders) <span> | ★ 46, pushed 792 days ago | </span> by @lithiumjake
+    -   [Vue in viewport detection directive](https://github.com/holic/vue-viewport) <span> | ★ 27, pushed 665 days ago | </span> by @holic
+    -   [Vue once directive](https://github.com/kewah/vue-once) <span> | ★ 10, pushed 497 days ago | </span> by @kewah
+    -   [Vue Modified Directive](https://github.com/KyleRoss/vue-modified) <span> | ★ 10, pushed 433 days ago | </span> by @KyleRoss
+    -   [Maintain scroll position on page changes](https://github.com/mark-hahn/vue-keep-scroll) <span> | ★ 16, pushed 29 days ago | </span> by @mark-hahn
+    -   [vue-titlecase](https://github.com/Haixing-Hu/vue-titlecase) <span> | ★ 9, pushed 163 days ago | </span> : A plugin providing a global filter and an instance method used to titlecase (different from capitalize) strings. By @Haixing-Hu
+    -   [vue-format](https://github.com/Haixing-Hu/vue-format) <span> | ★ 9, pushed 61 days ago | </span> : A plugin providing a global filter and an instance method used to format messages with arguments. By @Haixing-Hu application. By @Haixing-Hu
+    -   [vue-clickaway](https://github.com/simplesmiler/vue-clickaway) <span> | ★ 33, pushed 117 days ago | </span> : Assign a method to be called whenever user clicks away from the element. By @simplesmiler
+    -   [vue-focus](https://github.com/simplesmiler/vue-focus) <span> | ★ 31, pushed 117 days ago | </span> : Manage input focus in the MVVM-friendly way. By @simplesmiler
+    -   [vue-transfer-dom](https://github.com/rhyzx/vue-transfer-dom) <span> | ★ 17, pushed 30 days ago | </span> : Transfer DOM to another location. by @rhyzx
+    -   [vue-lazyload](https://github.com/hilongjw/vue-lazyload) <span> | ★ 58, pushed 4 days ago | </span> : lazyloading images. by @hilongjw
+    -   [v-touch](https://github.com/didierfranc/v-touch) <span> | ★ 5, pushed 73 days ago | </span> : The easiest way to use Hammer.js with Vue.js and use touch gestures. by [@didierfranc](https://github.com/didierfranc) <sup>Vue.js\\ 1.x</sup>
+    -   [vue-mixins](https://github.com/paulpflug/vue-mixins) <span> | ★ 9, pushed 7 days ago | </span> A collection of mixins aimed to replace some jQuery functionality
+    -   [vue-filters](https://github.com/paulpflug/vue-filters) A collection of filters
+    -   [vue-round-filter](https://github.com/rascada/vue-round-filter) <span> | ★ 0, pushed 64 days ago | </span> filter for rounding with whichever decimal accuracy
+    -   [vue-paginate](https://github.com/TahaSh/vue-paginate) <span> | ★ 40, pushed 17 days ago | </span> A simple plugin to use pagination in vue.js. by @TahaSh
+    -   [vue-super](https://github.com/rpkilby/vue-super) <span> | ★ 5, pushed 49 days ago | </span> A simple plugin to call methods on parent components.
+    -   [vue-deepstream](https://github.com/arexio/vue-deepstream) <span> | ★ 6, pushed 2 days ago | </span> Plugin to simplify event subscription and event trigger when using [deepstream.io](https://deepstream.io/)
+    -   [vue-plain](https://github.com/Coffcer/vue-plain) <span> | ★ 1, pushed 15 days ago | </span> Plugin to get plain object from vue getter/setter object.
+    -   [vue-calc-input](https://github.com/BosNaufal/vue-calc-input) <span> | ★ 1, pushed 39 days ago | </span> Vue directive to make a calculator input behavior by [@BosNaufal](https://github.com/BosNaufal)
+    -   [vue-move-dom](https://github.com/BosNaufal/vue-move-dom) <span> | ★ 1, pushed 39 days ago | </span> Vue Directive to move the DOM without losing all the VM data, event, etc. by [@BosNaufal](https://github.com/BosNaufal)
+    -   [vue-animate](https://github.com/haydenbbickerton/vue-animate) <span> | ★ 10, pushed 11 days ago | </span> : Use [Animate.css](https://github.com/daneden/animate.css "Animate.css") with Vue.js transitions. By [@haydenbbickerton](https://github.com/haydenbbickerton)
+    -   [vue-sortable](https://github.com/sagalbot/vue-sortable) <span> | ★ 16, pushed 13 days ago | </span> : A lightweight directive for reorderable drag-and-drop lists using [RubaXa/Sortable](https://github.com/RubaXa/Sortable) . By [@sagalbot](https://github.com/sagalbot)
+    -   [vue-loading](https://github.com/Coffcer/vue-loading) <span> | ★ 13, pushed 9 days ago | </span> : Vue directive, show loading block in any element. By [@coffcer](https://github.com/Coffcer)
+    -   [vue-gesture](https://github.com/mlyknown/vue-gesture) <span> | ★ 5, pushed 14 days ago | </span> :touch events plugin for Vue.js.You can v-gesture directive,and directive auguments can use a tap, swipe, etc.
+    -   [vue-lazyload-img](https://github.com/JALBAA/vue-lazyload-img) <span> | ★ 5, pushed 6 days ago | </span> another image lazyload plugin for Vue, especially optimized for mobile browser. By [@JALBAA](https://github.com/JALBAA)
+-   \#\#\#\# Talks
+
+    -   [Vue unit tests](http://www.slideshare.net/coulix/vuejs-testing) by [coulix](https://github.com/coulix)
+
+### Projects Using Vue.js
+
+-   \#\#\#\# Open Source
+
+    -   [PageKit](http://pagekit.com/) <sup>\[\[Source\]\](https://github.com/pagekit/pagekit)</sup>
+    -   [p5.js editor](http://p5js.org/download/) <sup>\[\[Source\]\](https://github.com/processing/p5.js-editor)</sup>
+    -   [Python China](https://python-china.org) <sup>\[\[Source\]\](https://github.com/zerqu/qingcheng)</sup>
+    -   [npmcharts.com](http://npmcharts.com) <sup>\[\[Source\]\](https://github.com/cheapsteak/npmcharts.com)</sup>
+    -   [Todolist](https://github.com/jiyinyiyong/todolist) by @jiyinyiyong
+    -   [Dashboard framework](https://github.com/thelinuxlich/vue-dashing-js) <span> | ★ 39, pushed 210 days ago | </span> by @thelinuxlich
+    -   [a simple notepad](https://github.com/sapjax/fewords) <span> | ★ 43, pushed 151 days ago | </span>
+    -   [FilterBlend](https://github.com/ilyashubin/FilterBlend) <span> | ★ 135, pushed 78 days ago | </span> : CSS blend modes and filters playground by @ilyashubin
+    -   [Koel](http://koel.phanan.net) : Music streaming server
+    -   [Selection Translator](https://chrome.google.com/webstore/detail/ikhdkkncnoglghljlkmcimlnlhkeamad) <sup>\[\[Source\]\](https://github.com/lmk123/crx-selection-translate)</sup> A Chrome Extension let browse any language websites has never been easier.
+    -   [SwitchHosts](https://oldj.github.io/SwitchHosts/) <sup>\[\[Source\]\](https://github.com/oldj/SwitchHosts)</sup> Switch hosts quickly.
+    -   [RSS Reader](https://github.com/mrgodhani/rss-reader) <span> | ★ 136, pushed 32 days ago | </span> Simple RSS Reader made using atom electron and vue.js.
+    -   [Gokotta](https://github.com/Zhangdroid/Gokotta) <span> | ★ 121, pushed 26 days ago | </span> : A simple music player built by electron and vue.
+    -   [Coffeebreak](https://github.com/Kocisov/coffeebreak) <span> | ★ 38, pushed 37 days ago | </span> Tool for live editing CSS components
+    -   [BaiduHui: Push Notification - 百度惠：实时推送优惠](https://chrome.google.com/webstore/detail/blcmlhpbpimcnifnkgkfjhhmoolbidik) <sup>\[\[Source\]\](https://github.com/DanielZhu/Magnet-baiduhui-chrome-extension)</sup> A Chrome Extension allows user use Baidu-Hui services and recieves the push notification about the latest discount infos.
+-   \#\#\#\# Apps/Websites
+
+    -   [Laravel Spark](https://spark.laravel.com/)
+    -   [Vice Video](https://video.vice.com/)
+    -   [Formlets](https://www.formlets.com)
+    -   [Laracasts](https://laracasts.com)
+    -   [Sainsbury's Entertainment onboarding platform](https://register.sainsburysentertainment.co.uk/)
+    -   [CUUSOO](https://cuusoo.com)
+    -   [esa.io](https://esa.io/)
+    -   [N1.ru](http://n1.ru)
+    -   [稀土掘金](http://gold.xitu.io)
+    -   [Prague Airport](http://www.prague-airport.com/)
+    -   [Expressionery](https://www.expressionery.com)
+    -   [BUYIT](http://bt.workswell.com.au) by @ [Workswell Australia](http://workswell.com.au)
+    -   [Portfolio Site](http://corentinbac.com/) by Corentin Bac
+    -   [Compare Prices by Currys & PCWorld](https://play.google.com/store/apps/details?id=uk.co.dixons.compareprices&hl=en)
+    -   [Grammarly](https://grammarly.com/) mistake-free writing service
+    -   [Laravist](https://laravist.com/)
+    -   [Atiiv](https://atiiv.com) An app aimed for personal trainers and their clients.
+    -   [Statamic](http://v2.statamic.com)
+    -   [Embalses!](http://embalses.azurewebsites.net/) A tool to report water dam level using the U.S. Geological Survey database.
+    -   [TravelMap](http://clem.travelmap.fr) A simple way for travellers to create a blog based on a Map
+    -   [movienote.org](http://movienote.org) A app which help users maintaining a list about what movie they have watched.
+    -   [Proper Cloth Shirt Builder](https://propercloth.com/design-a-shirt) Custom shirt builder
+    -   [CheckIt](https://github.com/julesbou/checkit) <span> | ★ 0, pushed 16 days ago | </span>
+    -   [Reddit News](https://github.com/Mati365/reddit-news) <span> | ★ 27, pushed 13 days ago | </span> A browser extension which show notifications and news from reddit
+    -   [Powerpuff Yourself by Cartoon Networks](https://www.powerpuffyourself.com/)
+    -   [小桃酱](https://app.xiaotaojiang.com/)
+-   \#\#\#\# Interactive Experiences
+
+    -   [Facebook NewsFeed](https://newsfeed.fb.com/)
+    -   [YouTube AdBlitz 2016](https://adblitz.withyoutube.com/#!/advertisers)
+    -   [Blood, Sweat and Tools](http://bloodsweatandtools.discovery.ca/gamebench/) - by Jam3, led by @cheapsteak
+    -   [Omnisense Experience](http://omnisense.net) - *Awwwards & FWA SOTD, FWA Cutting Edge. Awwwards SOTM nominee.*
+    -   [Being the Bear](https://danslapeaudelours.canalplus.fr/en/) - *Awwwards & FWA SOTD, FWA Cutting Edge, Awwwards SOTM nominee.*
+    -   [Heineken Star Experience](http://www.starexperience.fr/) - *FWA SOTD.*
+    -   [Louis Ansa Website (portfolio)](http://louisansa.com) - *Awwwards SOTD, FWA nominee.*
+    -   [Digital For All](http://www.digitalforallnow.com/en/experience)
+    -   [Djeco.com](http://www.djeco.com/en)
+-   \#\#\#\# Enterprise Usage
+
+    -   Alibaba
+    -   Baidu
+    -   Sina Weibo
+    -   Xiaomi
+    -   Ele.me
+    -   Optimizely
+    -   Expedia
+    -   UCWeb
+    -   Line
+    -   Nintendo
+    -   Celtra
+    -   Sainsbury's
+    -   [AREX](https://arex.io/)
+
+License
+-------
+
+[![CC0](https://i.creativecommons.org/p/zero/1.0/88x31.png)](https://creativecommons.org/publicdomain/zero/1.0/)

--- a/awesome_vue_with_repo_info.md
+++ b/awesome_vue_with_repo_info.md
@@ -1,356 +1,2428 @@
-<img src="https://rawgit.com/vuejs/awesome-vue/master/logo.png" alt="awesome" width="400" />
-
-Awesome Vue.js [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-> A curated list of awesome things related to Vue.js
-
--   [Official Resources](#official-resources)
--   [External Resources](#external-resources)
--   [Community](#community)
--   [Podcasts](#podcasts)
--   [Official Examples](#official-examples)
--   [Tutorials](#tutorials)
--   [Development Tools](#development-tools)
--   [Syntax Highlighting](#syntax-highlighting)
--   [Snippets](#snippets)
--   [Libraries & Plugins](#libraries--plugins)
-    -   [Routing](#routing)
-    -   [Ajax/Data](#ajaxdata)
-    -   [State Management](#state-management)
-    -   [Validation](#validation)
-    -   [UI Components](#ui-components)
-    -   [i18n](#i18n)
-    -   [Examples](#examples)
-    -   [Boilerplates](#boilerplates)
-    -   [Scaffolding](#scaffolding)
-    -   [Integrations](#integrations)
-    -   [General Plugins/Directives](#general-pluginsdirectives)
--   [Projects Using Vue.js](#projects-using-vuejs)
-    -   [Open Source](#open-source)
-    -   [Apps/Websites](#appswebsites)
-    -   [Interactive Experiences](#interactive-experiences)
-    -   [Enterprise Usage](#enterprise-usage)
-
-### Official Resources
-
--   [Official Guide](http://vuejs.org/guide/)
--   [API Reference](http://vuejs.org/api/)
--   [GitHub Repo](https://github.com/vuejs/vue) <span> | ★ 16753, pushed 0 days ago | </span>
--   [Release Notes](https://github.com/vuejs/vue/releases)
-
-### External Resources
-
--   [Vue.js資料まとめ(for japanese)](https://gist.github.com/hashrock/f575928d0e109ace9ad0) by @hashrock
-
-### Community
-
--   [Twitter](https://twitter.com/vuejs)
--   [Gitter Chat Room](https://gitter.im/vuejs/vue)
--   [Official Forum](http://forum.vuejs.org/)
--   [vue-requests](https://github.com/simplesmiler/vue-requests) - Request a Vue.js module you wish existed or get ideas for modules
-
-### Podcasts
-
--   [Full Stack Radio \#30 (11-23-2015)](http://www.fullstackradio.com/30)
--   [JavaScript Jabber \#187 (11-25-2015)](https://devchat.tv/js-jabber/187-jsj-vue-js-with-evan-you)
--   [Changelog \#184 (11-27-2015)](https://changelog.com/184/)
--   [Software Engineering Daily (12-29-2015)](http://softwareengineeringdaily.com/2015/12/29/front-end-javascript-with-evan-you/)
--   [Javascript Air 016 (03-30-2016)](https://javascriptair.com/episodes/2016-03-30/)
-
-### Official Examples
-
--   [Basic Examples](http://vuejs.org/guide/)
--   [Vue.js TodoMVC](https://github.com/vuejs/vue/tree/dev/examples/todomvc)
-    -   [CoffeeScript Version](https://github.com/anfelor/TodoMVC-CoffeeScript-and-Vue.js) <span> | ★ 3, pushed 51 days ago | </span>
--   [Vue.js HackerNews Clone](https://github.com/vuejs/vue-hackernews) <span> | ★ 891, pushed 55 days ago | </span>
-
-### Tutorials
-
--   [Vue.js screencasts](https://laracasts.com/series/learning-vue-step-by-step) on Laracasts
--   [What's New in Vue.js 1.0](http://www.sitepoint.com/whats-new-in-vue-js-1-0/) on Sitepoint
--   [Build an App with Vue.js: From Authentication to Calling an API](https://auth0.com/blog/2015/11/13/build-an-app-with-vuejs/) on Auth0 blog
--   [Create a GitHub File Explorer Using Vue.js](https://scotch.io/tutorials/create-a-github-file-explorer-using-vue-js) on Scotch.io
--   [Vue.js Tutorial](http://vegibit.com/vue-js-tutorial/) on Vegibit
--   [Vue.js build set-up from scratch with webpack, vue-loader and hot reload](http://skyronic.com/2015/12/28/vue-project-scratch/)
--   [Vuex basics: Tutorial and explanation](http://skyronic.com/2016/01/03/vuex-basics-tutorial/)
--   [Vuex introduction video - James Browne from London Vue.js Meetup \#1](https://www.youtube.com/watch?v=l1KHL-TX3qs)
--   [Vue.js 中文系列视频教程](https://laravist.com/series/vue-js-1-0-in-action-series) on Laravist
--   [Vue.js: The Basics](http://coligo.io/vuejs-the-basics/) on Coligo.io
--   [Practical Intro to Components in Vue.js](http://coligo.io/vuejs-components) on Coligo.io
--   [Develop a Reactive Invoice App using Vue.js](http://craigmckenna.com/develop-a-reactive-invoice-app-using-vue-js/) on craigmckenna.com
--   [Understanding Filters in Vue.js](http://coligo.io/vuejs-filters/) on Coligo.io
--   [Hybrid App Example with Laravel and Vue.js in portuguese](https://www.youtube.com/watch?v=TGSJjDahlrQ) by @vedovelli
--   [Creating a Markdown Editor with VueJs and GitHub's API](http://coligo.io/markdown-editor-vuejs/) on Coligo.io
--   [Building a Real-Time Web Analytics Dashboard with NodeJs, Socket.io, and VueJs](http://coligo.io/real-time-analytics-with-nodejs-socketio-vuejs/) on Coligo.io
--   [Vue.js Introduction Turkish Language](http://oguzhan.in/vue-js-ile-uygulama-gelistirme/) on oguzhan.in
--   [Vue.js VideoTutoral Series in Spanish (3-8-2016)](https://www.youtube.com/watch?v=IlFk3cyRB0Y&list=PLM-Y_YQmMEqD2EWfWpSbiV3WgShRRW3FE&index=7) on YouTube by Juan Andrés Núñez
--   [Building a Bookmarking App with Electron, VueJs, and Firebase](http://coligo.io/bookmarking-app-electron-vuejs-firebase/) on Coligo.io
-
-#### 0.12 and earlier
-
--   [Vue.js screencasts](https://laracasts.com/series/learning-vuejs) on Laracasts <sup>0.12</sup>
--   [Build an App with Vue.js](https://scotch.io/tutorials/build-an-app-with-vue-js-a-lightweight-alternative-to-angularjs) on Scotch.io <sup>0.12</sup>
--   [Getting Started with Vue.js](http://www.sitepoint.com/getting-started-with-vue-js/) on Sitepoint <sup>0.12</sup>
--   [Vue.js video series in portuguese](http://forum.vuejs.org/topic/49/vue-js-video-series-in-portuguese) <sup>0.12</sup>
--   [Vue.js video series in russian](http://ausite.ru/category/js/vue-js) on Ausite <sup>0.12</sup>
--   [A Quick Introduction to Vue.js](http://mattsparks.com/a-quick-introduction-to-vue-js/) by Matt Sparks <sup>0.12</sup>
--   [Getting Started with Vue.js + vue-router](https://www.youtube.com/watch?v=QN7l3ydXvx0) by Michael Calkins <sup>0.12</sup>
--   [Many JS Frameworks but Vue.js Is Different](http://taha-sh.com/blog/many-js-frameworks-but-vuejs-is-different) by Taha Shashtari <sup>0.12</sup>
--   [Getting Started with Vue.js - AngularJS perspective](http://fadeit.dk/blog/post/getting-started-with-vuejs-angularjs-perspective) by Dan Mindru <sup>0.11</sup>
-
-### Development Tools
-
--   [vue-cli](https://github.com/vuejs/vue-cli) <span> | ★ 561, pushed 9 days ago | </span> : official CLI for scaffolding Vue.js projects.
--   [vue-loader](https://github.com/vuejs/vue-loader) <span> | ★ 448, pushed 0 days ago | </span> - Vue component loader for Webpack.
-    -   [vue-loader-example](https://github.com/vuejs/vue-loader-example) <span> | ★ 312, pushed 47 days ago | </span>
--   [vueify](https://github.com/vuejs/vueify) <span> | ★ 405, pushed 2 days ago | </span> - Vue compcomponent transform for Browserify.
-    -   [vueify-example](https://github.com/vuejs/vueify-example) <span> | ★ 83, pushed 82 days ago | </span>
--   [vue-devtools](https://github.com/vuejs/vue-devtools) <span> | ★ 580, pushed 9 days ago | </span> - Chrome devtools extension for debugging Vue applications.
--   [grunt-vueify](https://github.com/SkewedAspect/grunt-vueify) <span> | ★ 1, pushed 53 days ago | </span> - Translate `    .vue   ` files to pure JavaScript, without using Browserify. (Useful for Electron apps)
--   [vue-compiler](https://github.com/paulpflug/vue-compiler) <span> | ★ 2, pushed 6 days ago | </span> - A simple CLI wrapper around vueify
--   [vue-autocompile](https://atom.io/packages/vue-autocompile) - Atom.io package to compile `    .vue   ` files on save.
--   [vue-dev-server](https://github.com/paulpflug/vue-dev-server) <span> | ★ 3, pushed 41 days ago | </span> - A small webpack-based development server for building standalone `    vue   ` components
--   [vue-go-cli](https://github.com/rodzzlessa24/vue-go-cli) <span> | ★ 2, pushed 47 days ago | </span> - a CLI tool for scaffolding new projects generating components, services, and mixins.
--   [brunch-vue](https://github.com/nblackburn/vue-brunch) <span> | ★ 2, pushed 43 days ago | </span> - Adds support to Brunch for pre-compiling single file Vue components.
--   [vueify-extract-css](https://github.com/rawcreative/vueify-extract-css) <span> | ★ 18, pushed 28 days ago | </span> - Browserify plugin to extract css from Vueify-compiled single file components to a separate css file.
--   [eslint-plugin-vue](https://github.com/twiknight/eslint-plugin-vue) <span> | ★ 19, pushed 20 days ago | </span> - Eslint plugin for .vue files.
-
-### Syntax Highlighting
-
--   [Sublime Text](https://github.com/vuejs/vue-syntax-highlight) <span> | ★ 162, pushed 10 days ago | </span>
--   [Atom](https://atom.io/packages/language-vue) by @hedefalk
--   [Atom (2)](https://atom.io/packages/language-vue-component) by @CYBAI
--   [Vim](https://github.com/posva/vim-vue) <span> | ★ 30, pushed 1 days ago | </span> by @darthmall and @posva
--   [Visual Studio Code](https://marketplace.visualstudio.com/items/liuji-jim.vue) by Jim Liu
--   [Brackets](https://github.com/pandao/brackets-vue) <span> | ★ 6, pushed 112 days ago | </span> by @pandao
--   [IntelliJ IDEA / WebStorm](https://github.com/henjue/vue-for-idea) <span> | ★ 134, pushed 27 days ago | </span> by @henjue
--   [Emacs](https://github.com/CodeFalling/vue-mode) <span> | ★ 2, pushed 8 days ago | </span> by @CodeFalling
-
-### Snippets
-
--   [vue-snippets](https://atom.io/packages/vue-snippets) for Atom.io by [@ealves-pt](https://github.com/ealves-pt)
-
-### Libraries & Plugins
-
--   \#\#\#\# Routing
-
-    -   [vue-router](https://github.com/vuejs/vue-router) <span> | ★ 1063, pushed 0 days ago | </span> - Official router for building SPAs. <sup>1.0\\ compatible</sup>
-    -   [Vue page](https://github.com/AlexToudic/vue-page) <span> | ★ 15, pushed 246 days ago | </span> , a routing system based on pagejs by @AlexToudic
-    -   [Vue Lanes](https://github.com/bpierre/vue-lanes) <span> | ★ 19, pushed 755 days ago | </span> , an event-based routing system for Vue by @bpierre
-    -   [Vue route](https://github.com/ayamflow/vue-route) <span> | ★ 70, pushed 257 days ago | </span> , ng-view inspired routes for Vue by @ayamflow
-    -   [voie](https://github.com/inca/voie) <span> | ★ 107, pushed 1 days ago | </span> — simple router / layout manager inspired by FSMs and ui-router by [Boris Okunskiy](https://github.com/inca) <sup>1.0</sup>
--   \#\#\#\# Ajax/Data
-
-    -   [vue-resource](https://github.com/vuejs/vue-resource) <span> | ★ 1136, pushed 33 days ago | </span> - AJAX/Resource plugin maintained by the [PageKit](http://pagekit.com/) team. <sup>1.0\\ compatible</sup>
-    -   [vue-async-data](https://github.com/vuejs/vue-async-data) <span> | ★ 174, pushed 1 days ago | </span> - Async data loading plugin <sup>1.0\\ compatible</sup>
-    -   [vue-async-computed](https://github.com/foxbenjaminfox/vue-async-computed) <span> | ★ 15, pushed 2 days ago | </span> - Plugin to support computed properties that are calculated asynchronously. By [@foxbenjaminfox](https://github.com/foxbenjaminfox)
--   \#\#\#\# State Management
-
-    -   [vuex](https://github.com/vuejs/vuex) <span> | ★ 1174, pushed 0 days ago | </span> - Flux/Redux inspired application architecture for Vue.js.
-    -   [revue](https://github.com/egoist/revue) - Redux binding for Vue by @egoist
-    -   [vue-redux](https://github.com/yang-wei/vue-redux) <span> | ★ 74, pushed 74 days ago | </span> - Redux binding for Vue by @yang-wei
-    -   [vue-freeze](https://github.com/BosNaufal/vue-freeze) <span> | ★ 28, pushed 20 days ago | </span> - Simple state management whitout bloating API and Concept for Vue by [@BosNaufal](https://github.com/BosNaufal)
-    -   [vue-simple-store](https://github.com/BosNaufal/vue-simple-store) <span> | ★ 24, pushed 21 days ago | </span> - Store Organizer To Simplify Your Stores for Vue By [@BosNaufal](https://github.com/BosNaufal)
--   \#\#\#\# Validation
-
-    -   [vue-validator](https://github.com/vuejs/vue-validator) <span> | ★ 531, pushed 0 days ago | </span> - Form validation plugin maintained by @kazupon <sup>1.0\\ compatible</sup>
-    -   [Vue validator](https://github.com/xrado/vue-validator) <span> | ★ 34, pushed 194 days ago | </span> by @xrado
-    -   [vue-form](https://github.com/fergaldoyle/vue-form) <span> | ★ 105, pushed 1 days ago | </span> by @fergaldoyle <sup>1.0\\ compatible</sup>
--   \#\#\#\# UI Components
-
-    -   [VueStrap](http://yuche.github.io/vue-strap/) , Bootstrap components built with pure Vue.js by @yuche <sup>1.0</sup>
-    -   [VueBoot](http://morgul.github.io/vueboot/) , Bootstrap v4 components by @Morgul <sup>1.0</sup>
-    -   [vue-mdl](https://github.com/posva/vue-mdl) <span> | ★ 280, pushed 3 days ago | </span> : Reusable Vue.js components using Material Design Lite. By [@posva](https://github.com/posva)
-    -   [vue-countup](https://github.com/samcrosoft/vue-countup) <span> | ★ 8, pushed 77 days ago | </span> : A Vue.js component for the very interesting [CountUp.js](https://inorganik.github.io/countUp.js/) plugin. <sup>1.0\\ compatible</sup>
-    -   [Vue Tag Editor Component](https://github.com/hnakamur/vue.tag-editor.js) <span> | ★ 19, pushed 761 days ago | </span> by @hnakamur
-    -   [Vue Crop](http://pespantelis.github.io/vue-crop/)
-    -   [Vue Typeahead](http://pespantelis.github.io/vue-typeahead/)
-    -   [Typed select component](https://github.com/dgerber/vue-select-js) <span> | ★ 3, pushed 320 days ago | </span> by @dgerber
-    -   [vue-select](https://github.com/Haixing-Hu/vue-select) <span> | ★ 44, pushed 42 days ago | </span> : A Vue.js component implementing the select control with the [jQuery select2 plugin](https://github.com/select2/select2) . By @Haixing-Hu
-    -   [vue-html-editor](https://github.com/Haixing-Hu/vue-html-editor) <span> | ★ 54, pushed 78 days ago | </span> : A Vue.js component implementing the HTML editor with the [jQuery summernote plugin](https://github.com/summernote/summernote) . By @Haixing-Hu
-    -   [vue-datetime-picker](https://github.com/Haixing-Hu/vue-datetime-picker) <span> | ★ 53, pushed 16 days ago | </span> : A Vue.js component implementing the datetime picker control using the [Eonasdan's bootstrap datetime picker plugin](https://github.com/Eonasdan/bootstrap-datetimepicker) . By @Haixing-Hu
-    -   [vue-country-select](https://github.com/Haixing-Hu/vue-country-select) <span> | ★ 11, pushed 191 days ago | </span> : A Vue.js component implementing the select control used to select countries. It depends on [vue-select](https://github.com/Haixing-Hu/vue-select) and [vue-i18n](https://github.com/Haixing-Hu/vue-i18n) . By @Haixing-Hu
-    -   [Form generation from JSON Schema](https://github.com/dgerber/vue-formidable) <span> | ★ 19, pushed 319 days ago | </span> by @dgerber
-    -   [vue-panel](https://github.com/ericmcdaniel/vue-panel) <span> | ★ 36, pushed 111 days ago | </span> : A suite of Vue.js components for building Flexbox layouts by @ericmcdaniel
-    -   [vue-google-maps](https://github.com/GuillaumeLeclerc/vue-google-maps/) : A suite of Vue.js components to build reactive Google Maps Applications by @GuillaumeLeclerc
-    -   [vue-transition](https://github.com/Twiknight/vue-transition) <span> | ★ 33, pushed 48 days ago | </span> : A component to trigger a CSS transition at any time by @Twiknight
-    -   [SVG icons](http://kzima.github.io/vuestrap-icons/#/icons) , SVG sprites in form of a simple `           ` component, by @kzima <sup>1.0</sup>
-    -   [Extra Vuestrap components](http://gritcode.github.io/gritcode-components/#/toast) , more components built with just B4 and Vue.js, by @kzima <sup>1.0</sup>
-    -   [VueStrap Base Components](http://kzima.github.io/vuestrap-base-components/#/accordion) , A complete set of Bootstrap 4 web components built with pure Vue.js, by @kzima <sup>1.0</sup>
-    -   [Vue YouTube Embed](https://github.com/kaorun343/vue-youtube-embed) <span> | ★ 16, pushed 28 days ago | </span> : a directive for Vue.js and YouTube by @kaorun343
-    -   [Vue datepicker](https://github.com/hilongjw/vue-datepicker) <span> | ★ 48, pushed 0 days ago | </span> : calendar and datepicker component with material design for Vue.js by @hilongjw
-    -   [vue-date-picker](https://github.com/Bubblings/vue-date-picker) <span> | ★ 15, pushed 7 days ago | </span> : A simple datepicker component for Vue.js by @Bubblings
-    -   [vue-spinner](https://github.com/greyby/vue-spinner) <span> | ★ 128, pushed 53 days ago | </span> : A collection of loading spinners with Vue.js.
-    -   [vue-image-loader](https://github.com/eduardostuart/vue-image-loader) <span> | ★ 13, pushed 72 days ago | </span> : Async image loader for Vue.js by @eduardostuart
-    -   [Vue-progressbar](https://github.com/hilongjw/vue-progressbar) <span> | ★ 35, pushed 72 days ago | </span> : A lightweight progress bar for Vue.js by @hilongjw
-    -   [Famous-Vue](https://github.com/irwansyahwii/Famous-Vue) <span> | ★ 10, pushed 63 days ago | </span> : Declarative Famous using Vue
-    -   [vue-waterfall](https://github.com/MopTym/vue-waterfall) <span> | ★ 197, pushed 53 days ago | </span> : A waterfall layout component for Vue.js by @MopTym
-    -   [vue-charts](https://github.com/haydenbbickerton/vue-charts) <span> | ★ 17, pushed 14 days ago | </span> : A Google Charts plugin for Vue.js by [@haydenbbickerton](https://github.com/haydenbbickerton)
-    -   [vux](https://github.com/airyland/vux) <span> | ★ 1046, pushed 0 days ago | </span> : Mobile web UI Components based on Vue and WeUI
-    -   [vue-select](https://github.com/sagalbot/vue-select) <span> | ★ 154, pushed 7 days ago | </span> : Simple component that implements Select2/Chosen style dropdowns with no dependencies <sup>1.0</sup>
-    -   [Vue-slide](https://github.com/hilongjw/vue-slide) <span> | ★ 27, pushed 18 days ago | </span> : A lightweight slide component for Vue.js by @hilongjw
-    -   [Vue-quill](https://github.com/CroudSupport/vue-quill) <span> | ★ 5, pushed 21 days ago | </span> : A Vue component implementing the [Quill](https://github.com/quilljs/quill.git) text editor by @brockreece
-    -   [vue-pagenav](https://github.com/zxdong262/vue-pagenav) <span> | ★ 6, pushed 3 days ago | </span> : A vue pagenav plugin by [@zxdong262](https://github.com/zxdong262)
-    -   [Vue-calendar](https://github.com/cucygh/vue-calendar) <span> | ★ 1, pushed 22 days ago | </span> : A vue calendar component with less code by cucygh
-    -   [Vue Material Components](http://appcomponents.org/material-components/) : Vue.js UI components using [materializecss.com](http://materializecss.com/) by mjanys
-    -   [vue-autocomplete](https://github.com/BosNaufal/vue-autocomplete) <span> | ★ 21, pushed 93 days ago | </span> Autocomplete Component for Vue by [@BosNaufal](https://github.com/BosNaufal)
-    -   [vue-loading-bar](https://github.com/BosNaufal/vue-loading-bar) <span> | ★ 25, pushed 9 days ago | </span> Youtube Like Loading Bar Component for Vue by [@BosNaufal](https://github.com/BosNaufal)
-    -   [vue-bootstrap-modal](https://github.com/Coffcer/vue-bootstrap-modal) <span> | ★ 5, pushed 2 days ago | </span> Bootstrap style modal component for Vue by [@Coffcer](https://github.com/Coffcer)
-    -   [vue-comps](https://github.com/vue-comps) : A collection of unstyled and unanimated components (side-nav / modal / collapsible / clusterize / dropdown / resize-handle and other)
-    -   [vue-materialize](https://github.com/paulpflug/vue-materialize) <span> | ★ 20, pushed 0 days ago | </span> : materializeCss styles and animations for some of [vue-comps](https://github.com/vue-comps)
-    -   [vue-waves](https://github.com/Teddy-Zhu/vue-waves) <span> | ★ 3, pushed 7 days ago | </span> :Click effect inspired by Google's Material Design ,the vue version By @Teddy-Zhu
-    -   [vue-table](https://github.com/ratiw/vue-table) <span> | ★ 24, pushed 2 days ago | </span> : component that will automatically request (JSON) data from the server and display them nicely in html table with swappable/extensible pagination component. By @ratiw
-    -   [fire-select](https://github.com/firework/fire-select) <span> | ★ 20, pushed 0 days ago | </span> : Vue component that transforms overwhelming select boxes into something fancy, simple and user-friendly. It is similar to Selectize, Chosen, Select2, etc.
--   \#\#\#\# i18n
-
-    -   [vue-i18n](https://github.com/kazupon/vue-i18n) <span> | ★ 163, pushed 0 days ago | </span> : Internationalization plugin.
-    -   [vue-i18n](https://github.com/Haixing-Hu/vue-i18n) <span> | ★ 32, pushed 1 days ago | </span> : A plugin providing a global interface used to localize internationalized messages used in the
-    -   [vue-locale](https://github.com/sebastian-software/vue-locale) <span> | ★ 9, pushed 33 days ago | </span> : Advanced localization support for VueJS
-    -   [vue-jade-editor](https://github.com/zxdong262/vue-jade-editor) <span> | ★ 0, pushed 7 days ago | </span> : a online jade(pug) editor plugin by [@zxdong262](https://github.com/zxdong262)
--   \#\#\#\# Examples
-
-    -   [Starter Application with JWT Auth + sample backend API in Laravel](http://forum.vuejs.org/topic/39/starter-application-with-jwt-auth-sample-backend-api)
-    -   [Node Webkit + Vue example](https://github.com/brandonjpierce/node-webkit-boilerplate) <span> | ★ 34, pushed 286 days ago | </span> by @brandonjpierce
-    -   [Vue Samples](https://github.com/superlloyd/VueSamples) <span> | ★ 18, pushed 174 days ago | </span> by @superlloyd
-    -   [HackerNews clone with vue.js + vue-router](https://github.com/kazupon/vue-router-hackernews) <span> | ★ 2, pushed 239 days ago | </span> by @kazupon
-    -   [Electron + Vue example](https://github.com/bradstewart/electron-boilerplate-vue) <span> | ★ 141, pushed 0 days ago | </span> by @bradstewart
-    -   [Single page application example (Vue + Voie)](https://github.com/inca/voie-example) <span> | ★ 30, pushed 107 days ago | </span> by [Boris Okunskiy](https://github.com/inca)
-    -   [Begin - Task Manager SPA written in Vue + Lumen](https://github.com/rajabishek/begin) <span> | ★ 10, pushed 24 days ago | </span> by [Raj Abishek](https://github.com/rajabishek)
-    -   [Vue Mini Shop](https://github.com/BosNaufal/vue-mini-shop) <span> | ★ 10, pushed 21 days ago | </span> by [BosNaufal](https://github.com/BosNaufal)
-    -   [Vue SoundCloud](https://github.com/mul14/vue-soundcloud) <span> | ★ 11, pushed 18 days ago | </span> by [mul14](https://github.com/mul14)
--   \#\#\#\# Boilerplates
-
-    -   [Boilerplate for Vue.js plugin](https://github.com/kazupon/vue-plugin-boilerplate) <span> | ★ 16, pushed 51 days ago | </span> by @kazupon
-    -   [Boilerplate for Vue.js & Atom Electron](https://github.com/rodzzlessa24/vue-electron) <span> | ★ 33, pushed 13 days ago | </span> by @rodzzlessa24
--   \#\#\#\# Scaffolding
-
-    -   [vue-cli](https://github.com/vuejs/vue-cli) : official CLI for scaffolding Vue.js projects.
-    -   [Vue generator](https://github.com/BirdEggegg/generator-vue) : a simple yeoman generator for Vue by @BirdEggegg
-    -   [VENM stack yeoman generator](https://github.com/jfelsinger/generator-venm) <span> | ★ 35, pushed 119 days ago | </span> by @jfelsinger
-    -   [Grail Yeoman Generator](https://github.com/mustardamus/generator-grail) <span> | ★ 9, pushed 166 days ago | </span> : a advanced yeoman generator for a modern modular one page web app, extendable with Vue.js alongside other nice tools
-    -   [VuePack](https://github.com/egoist/vuepack) <span> | ★ 157, pushed 5 days ago | </span> : A modern starter for Vue and Webpack by @egoist
-    -   [VueWebgulp](https://github.com/rodzzlessa24/vue-webgulp) <span> | ★ 31, pushed 29 days ago | </span> : A skeleton app using Vuejs, Gulp, and Webpack by @rodzzlessa24
-    -   [Vuetober](https://github.com/scottbedard/oc-vuetober-theme) <span> | ★ 21, pushed 25 days ago | </span> : SPA scaffolding for October CMS
-    -   [vue-go-cli](https://github.com/rodzzlessa24/vue-go-cli) - a CLI tool for scaffolding new projects generating components, services, and mixins.
-    -   [Brunch with Vue](https://github.com/nblackburn/brunch-with-vue) <span> | ★ 9, pushed 36 days ago | </span> - A skeleton application utilizing vue, vuex, vue-resource and vue-router.
--   \#\#\#\# Integrations
-
-    -   [Vue for Meteor](https://github.com/zhouzhuojie/meteor-vue) <span> | ★ 74, pushed 113 days ago | </span> by @zhouzhuojie
-    -   [ScalaJS bindings for Vue.js](https://github.com/fancellu/scalajs-vue) <span> | ★ 22, pushed 176 days ago | </span> by @fancellu
-    -   [Socketize Backend](https://github.com/Socketize/vue.js-plugin) <span> | ★ 6, pushed 117 days ago | </span> : Sync your model data to Socketize backend automatically. By [@Socketize](https://github.com/Socketize)
-    -   [Vue-Meteor-Data](https://github.com/Grottolabs/vue-meteor-data) <span> | ★ 12, pushed 2 days ago | </span> Two-way-reactivity mixin for Vue and Meteor by @JakobRosenberg
-    -   [Vue Proerty Decorator](https://github.com/kaorun343/vue-property-decorator) <span> | ★ 7, pushed 86 days ago | </span> : Property Decorators for Vue.js by @kaorun343
--   \#\#\#\# General Plugins/Directives
-
-    -   [vue-element](https://github.com/vuejs/vue-element) <span> | ★ 72, pushed 325 days ago | </span> : Register real custom elements with Vue.
-    -   [vue-touch](https://github.com/vuejs/vue-touch) <span> | ★ 217, pushed 14 days ago | </span> : Hammer.js wrapper directives for touch gestures. (Updated for 1.0!)
-    -   [vue-animated-list](https://github.com/vuejs/vue-animated-list) <span> | ★ 85, pushed 62 days ago | </span> : A Vue.js plugin for easily animating `      v-for     ` rendered lists.
-    -   [Vue placeholder directives](https://github.com/lithiumjake/vue-placeholders) <span> | ★ 46, pushed 792 days ago | </span> by @lithiumjake
-    -   [Vue in viewport detection directive](https://github.com/holic/vue-viewport) <span> | ★ 27, pushed 665 days ago | </span> by @holic
-    -   [Vue once directive](https://github.com/kewah/vue-once) <span> | ★ 10, pushed 497 days ago | </span> by @kewah
-    -   [Vue Modified Directive](https://github.com/KyleRoss/vue-modified) <span> | ★ 10, pushed 433 days ago | </span> by @KyleRoss
-    -   [Maintain scroll position on page changes](https://github.com/mark-hahn/vue-keep-scroll) <span> | ★ 16, pushed 29 days ago | </span> by @mark-hahn
-    -   [vue-titlecase](https://github.com/Haixing-Hu/vue-titlecase) <span> | ★ 9, pushed 163 days ago | </span> : A plugin providing a global filter and an instance method used to titlecase (different from capitalize) strings. By @Haixing-Hu
-    -   [vue-format](https://github.com/Haixing-Hu/vue-format) <span> | ★ 9, pushed 61 days ago | </span> : A plugin providing a global filter and an instance method used to format messages with arguments. By @Haixing-Hu application. By @Haixing-Hu
-    -   [vue-clickaway](https://github.com/simplesmiler/vue-clickaway) <span> | ★ 33, pushed 117 days ago | </span> : Assign a method to be called whenever user clicks away from the element. By @simplesmiler
-    -   [vue-focus](https://github.com/simplesmiler/vue-focus) <span> | ★ 31, pushed 117 days ago | </span> : Manage input focus in the MVVM-friendly way. By @simplesmiler
-    -   [vue-transfer-dom](https://github.com/rhyzx/vue-transfer-dom) <span> | ★ 17, pushed 30 days ago | </span> : Transfer DOM to another location. by @rhyzx
-    -   [vue-lazyload](https://github.com/hilongjw/vue-lazyload) <span> | ★ 58, pushed 4 days ago | </span> : lazyloading images. by @hilongjw
-    -   [v-touch](https://github.com/didierfranc/v-touch) <span> | ★ 5, pushed 73 days ago | </span> : The easiest way to use Hammer.js with Vue.js and use touch gestures. by [@didierfranc](https://github.com/didierfranc) <sup>Vue.js\\ 1.x</sup>
-    -   [vue-mixins](https://github.com/paulpflug/vue-mixins) <span> | ★ 9, pushed 7 days ago | </span> A collection of mixins aimed to replace some jQuery functionality
-    -   [vue-filters](https://github.com/paulpflug/vue-filters) A collection of filters
-    -   [vue-round-filter](https://github.com/rascada/vue-round-filter) <span> | ★ 0, pushed 64 days ago | </span> filter for rounding with whichever decimal accuracy
-    -   [vue-paginate](https://github.com/TahaSh/vue-paginate) <span> | ★ 40, pushed 17 days ago | </span> A simple plugin to use pagination in vue.js. by @TahaSh
-    -   [vue-super](https://github.com/rpkilby/vue-super) <span> | ★ 5, pushed 49 days ago | </span> A simple plugin to call methods on parent components.
-    -   [vue-deepstream](https://github.com/arexio/vue-deepstream) <span> | ★ 6, pushed 2 days ago | </span> Plugin to simplify event subscription and event trigger when using [deepstream.io](https://deepstream.io/)
-    -   [vue-plain](https://github.com/Coffcer/vue-plain) <span> | ★ 1, pushed 15 days ago | </span> Plugin to get plain object from vue getter/setter object.
-    -   [vue-calc-input](https://github.com/BosNaufal/vue-calc-input) <span> | ★ 1, pushed 39 days ago | </span> Vue directive to make a calculator input behavior by [@BosNaufal](https://github.com/BosNaufal)
-    -   [vue-move-dom](https://github.com/BosNaufal/vue-move-dom) <span> | ★ 1, pushed 39 days ago | </span> Vue Directive to move the DOM without losing all the VM data, event, etc. by [@BosNaufal](https://github.com/BosNaufal)
-    -   [vue-animate](https://github.com/haydenbbickerton/vue-animate) <span> | ★ 10, pushed 11 days ago | </span> : Use [Animate.css](https://github.com/daneden/animate.css "Animate.css") with Vue.js transitions. By [@haydenbbickerton](https://github.com/haydenbbickerton)
-    -   [vue-sortable](https://github.com/sagalbot/vue-sortable) <span> | ★ 16, pushed 13 days ago | </span> : A lightweight directive for reorderable drag-and-drop lists using [RubaXa/Sortable](https://github.com/RubaXa/Sortable) . By [@sagalbot](https://github.com/sagalbot)
-    -   [vue-loading](https://github.com/Coffcer/vue-loading) <span> | ★ 13, pushed 9 days ago | </span> : Vue directive, show loading block in any element. By [@coffcer](https://github.com/Coffcer)
-    -   [vue-gesture](https://github.com/mlyknown/vue-gesture) <span> | ★ 5, pushed 14 days ago | </span> :touch events plugin for Vue.js.You can v-gesture directive,and directive auguments can use a tap, swipe, etc.
-    -   [vue-lazyload-img](https://github.com/JALBAA/vue-lazyload-img) <span> | ★ 5, pushed 6 days ago | </span> another image lazyload plugin for Vue, especially optimized for mobile browser. By [@JALBAA](https://github.com/JALBAA)
--   \#\#\#\# Talks
-
-    -   [Vue unit tests](http://www.slideshare.net/coulix/vuejs-testing) by [coulix](https://github.com/coulix)
-
-### Projects Using Vue.js
-
--   \#\#\#\# Open Source
-
-    -   [PageKit](http://pagekit.com/) <sup>\[\[Source\]\](https://github.com/pagekit/pagekit)</sup>
-    -   [p5.js editor](http://p5js.org/download/) <sup>\[\[Source\]\](https://github.com/processing/p5.js-editor)</sup>
-    -   [Python China](https://python-china.org) <sup>\[\[Source\]\](https://github.com/zerqu/qingcheng)</sup>
-    -   [npmcharts.com](http://npmcharts.com) <sup>\[\[Source\]\](https://github.com/cheapsteak/npmcharts.com)</sup>
-    -   [Todolist](https://github.com/jiyinyiyong/todolist) by @jiyinyiyong
-    -   [Dashboard framework](https://github.com/thelinuxlich/vue-dashing-js) <span> | ★ 39, pushed 210 days ago | </span> by @thelinuxlich
-    -   [a simple notepad](https://github.com/sapjax/fewords) <span> | ★ 43, pushed 151 days ago | </span>
-    -   [FilterBlend](https://github.com/ilyashubin/FilterBlend) <span> | ★ 135, pushed 78 days ago | </span> : CSS blend modes and filters playground by @ilyashubin
-    -   [Koel](http://koel.phanan.net) : Music streaming server
-    -   [Selection Translator](https://chrome.google.com/webstore/detail/ikhdkkncnoglghljlkmcimlnlhkeamad) <sup>\[\[Source\]\](https://github.com/lmk123/crx-selection-translate)</sup> A Chrome Extension let browse any language websites has never been easier.
-    -   [SwitchHosts](https://oldj.github.io/SwitchHosts/) <sup>\[\[Source\]\](https://github.com/oldj/SwitchHosts)</sup> Switch hosts quickly.
-    -   [RSS Reader](https://github.com/mrgodhani/rss-reader) <span> | ★ 136, pushed 32 days ago | </span> Simple RSS Reader made using atom electron and vue.js.
-    -   [Gokotta](https://github.com/Zhangdroid/Gokotta) <span> | ★ 121, pushed 26 days ago | </span> : A simple music player built by electron and vue.
-    -   [Coffeebreak](https://github.com/Kocisov/coffeebreak) <span> | ★ 38, pushed 37 days ago | </span> Tool for live editing CSS components
-    -   [BaiduHui: Push Notification - 百度惠：实时推送优惠](https://chrome.google.com/webstore/detail/blcmlhpbpimcnifnkgkfjhhmoolbidik) <sup>\[\[Source\]\](https://github.com/DanielZhu/Magnet-baiduhui-chrome-extension)</sup> A Chrome Extension allows user use Baidu-Hui services and recieves the push notification about the latest discount infos.
--   \#\#\#\# Apps/Websites
-
-    -   [Laravel Spark](https://spark.laravel.com/)
-    -   [Vice Video](https://video.vice.com/)
-    -   [Formlets](https://www.formlets.com)
-    -   [Laracasts](https://laracasts.com)
-    -   [Sainsbury's Entertainment onboarding platform](https://register.sainsburysentertainment.co.uk/)
-    -   [CUUSOO](https://cuusoo.com)
-    -   [esa.io](https://esa.io/)
-    -   [N1.ru](http://n1.ru)
-    -   [稀土掘金](http://gold.xitu.io)
-    -   [Prague Airport](http://www.prague-airport.com/)
-    -   [Expressionery](https://www.expressionery.com)
-    -   [BUYIT](http://bt.workswell.com.au) by @ [Workswell Australia](http://workswell.com.au)
-    -   [Portfolio Site](http://corentinbac.com/) by Corentin Bac
-    -   [Compare Prices by Currys & PCWorld](https://play.google.com/store/apps/details?id=uk.co.dixons.compareprices&hl=en)
-    -   [Grammarly](https://grammarly.com/) mistake-free writing service
-    -   [Laravist](https://laravist.com/)
-    -   [Atiiv](https://atiiv.com) An app aimed for personal trainers and their clients.
-    -   [Statamic](http://v2.statamic.com)
-    -   [Embalses!](http://embalses.azurewebsites.net/) A tool to report water dam level using the U.S. Geological Survey database.
-    -   [TravelMap](http://clem.travelmap.fr) A simple way for travellers to create a blog based on a Map
-    -   [movienote.org](http://movienote.org) A app which help users maintaining a list about what movie they have watched.
-    -   [Proper Cloth Shirt Builder](https://propercloth.com/design-a-shirt) Custom shirt builder
-    -   [CheckIt](https://github.com/julesbou/checkit) <span> | ★ 0, pushed 16 days ago | </span>
-    -   [Reddit News](https://github.com/Mati365/reddit-news) <span> | ★ 27, pushed 13 days ago | </span> A browser extension which show notifications and news from reddit
-    -   [Powerpuff Yourself by Cartoon Networks](https://www.powerpuffyourself.com/)
-    -   [小桃酱](https://app.xiaotaojiang.com/)
--   \#\#\#\# Interactive Experiences
-
-    -   [Facebook NewsFeed](https://newsfeed.fb.com/)
-    -   [YouTube AdBlitz 2016](https://adblitz.withyoutube.com/#!/advertisers)
-    -   [Blood, Sweat and Tools](http://bloodsweatandtools.discovery.ca/gamebench/) - by Jam3, led by @cheapsteak
-    -   [Omnisense Experience](http://omnisense.net) - *Awwwards & FWA SOTD, FWA Cutting Edge. Awwwards SOTM nominee.*
-    -   [Being the Bear](https://danslapeaudelours.canalplus.fr/en/) - *Awwwards & FWA SOTD, FWA Cutting Edge, Awwwards SOTM nominee.*
-    -   [Heineken Star Experience](http://www.starexperience.fr/) - *FWA SOTD.*
-    -   [Louis Ansa Website (portfolio)](http://louisansa.com) - *Awwwards SOTD, FWA nominee.*
-    -   [Digital For All](http://www.digitalforallnow.com/en/experience)
-    -   [Djeco.com](http://www.djeco.com/en)
--   \#\#\#\# Enterprise Usage
-
-    -   Alibaba
-    -   Baidu
-    -   Sina Weibo
-    -   Xiaomi
-    -   Ele.me
-    -   Optimizely
-    -   Expedia
-    -   UCWeb
-    -   Line
-    -   Nintendo
-    -   Celtra
-    -   Sainsbury's
-    -   [AREX](https://arex.io/)
-
-License
--------
-
-[![CC0](https://i.creativecommons.org/p/zero/1.0/88x31.png)](https://creativecommons.org/publicdomain/zero/1.0/)
+<p align="center">
+ <br>
+  <img alt="awesome" src="https://rawgit.com/vuejs/awesome-vue/master/logo.png" width="400">
+   <br>
+    <br>
+    </br>
+   </br>
+  </img>
+ </br>
+</p>
+<h2>
+ Awesome Vue.js
+ <a href="https://github.com/sindresorhus/awesome">
+  <img alt="Awesome" src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg"/>
+ </a>
+</h2>
+<blockquote>
+ <p>
+  A curated list of awesome things related to Vue.js
+ </p>
+</blockquote>
+<ul>
+ <li>
+  <a href="#official-resources">
+   Official Resources
+  </a>
+ </li>
+ <li>
+  <a href="#external-resources">
+   External Resources
+  </a>
+ </li>
+ <li>
+  <a href="#community">
+   Community
+  </a>
+ </li>
+ <li>
+  <a href="#podcasts">
+   Podcasts
+  </a>
+ </li>
+ <li>
+  <a href="#official-examples">
+   Official Examples
+  </a>
+ </li>
+ <li>
+  <a href="#tutorials">
+   Tutorials
+  </a>
+ </li>
+ <li>
+  <a href="#development-tools">
+   Development Tools
+  </a>
+ </li>
+ <li>
+  <a href="#syntax-highlighting">
+   Syntax Highlighting
+  </a>
+ </li>
+ <li>
+  <a href="#snippets">
+   Snippets
+  </a>
+ </li>
+ <li>
+  <a href="#autocomplete">
+   Autocomplete
+  </a>
+ </li>
+ <li>
+  <a href="#libraries--plugins">
+   Libraries & Plugins
+  </a>
+  <ul>
+   <li>
+    <a href="#routing">
+     Routing
+    </a>
+   </li>
+   <li>
+    <a href="#ajaxdata">
+     Ajax/Data
+    </a>
+   </li>
+   <li>
+    <a href="#state-management">
+     State Management
+    </a>
+   </li>
+   <li>
+    <a href="#validation">
+     Validation
+    </a>
+   </li>
+   <li>
+    <a href="#ui-components">
+     UI Components
+    </a>
+   </li>
+   <li>
+    <a href="#i18n">
+     i18n
+    </a>
+   </li>
+   <li>
+    <a href="#examples">
+     Examples
+    </a>
+   </li>
+   <li>
+    <a href="#boilerplates">
+     Boilerplates
+    </a>
+   </li>
+   <li>
+    <a href="#scaffolding">
+     Scaffolding
+    </a>
+   </li>
+   <li>
+    <a href="#integrations">
+     Integrations
+    </a>
+   </li>
+   <li>
+    <a href="#general-pluginsdirectives">
+     General Plugins/Directives
+    </a>
+   </li>
+  </ul>
+ </li>
+ <li>
+  <a href="#projects-using-vuejs">
+   Projects Using Vue.js
+  </a>
+  <ul>
+   <li>
+    <a href="#open-source">
+     Open Source
+    </a>
+   </li>
+   <li>
+    <a href="#appswebsites">
+     Apps/Websites
+    </a>
+   </li>
+   <li>
+    <a href="#interactive-experiences">
+     Interactive Experiences
+    </a>
+   </li>
+   <li>
+    <a href="#enterprise-usage">
+     Enterprise Usage
+    </a>
+   </li>
+  </ul>
+ </li>
+</ul>
+<h3>
+ Official Resources
+</h3>
+<ul>
+ <li>
+  <a href="http://vuejs.org/guide/">
+   Official Guide
+  </a>
+ </li>
+ <li>
+  <a href="http://vuejs.org/api/">
+   API Reference
+  </a>
+ </li>
+ <li>
+  <a href="https://github.com/vuejs/vue">
+   GitHub Repo
+  </a>
+  <sup>
+   &#9733 16889, pushed 0 days ago
+  </sup>
+ </li>
+ <li>
+  <a href="https://github.com/vuejs/vue/releases">
+   Release Notes
+  </a>
+ </li>
+</ul>
+<h3>
+ External Resources
+</h3>
+<ul>
+ <li>
+  <a href="https://gist.github.com/hashrock/f575928d0e109ace9ad0">
+   Vue.js資料まとめ(for japanese)
+  </a>
+  by @hashrock
+ </li>
+</ul>
+<h3>
+ Community
+</h3>
+<ul>
+ <li>
+  <a href="https://twitter.com/vuejs">
+   Twitter
+  </a>
+ </li>
+ <li>
+  <a href="https://gitter.im/vuejs/vue">
+   Gitter Chat Room
+  </a>
+ </li>
+ <li>
+  <a href="http://forum.vuejs.org/">
+   Official Forum
+  </a>
+ </li>
+ <li>
+  <a href="https://github.com/simplesmiler/vue-requests">
+   vue-requests
+  </a>
+  - Request a Vue.js module you wish existed or get ideas for modules
+ </li>
+</ul>
+<h3>
+ Podcasts
+</h3>
+<ul>
+ <li>
+  <a href="http://www.fullstackradio.com/30">
+   Full Stack Radio #30 (11-23-2015)
+  </a>
+ </li>
+ <li>
+  <a href="https://devchat.tv/js-jabber/187-jsj-vue-js-with-evan-you">
+   JavaScript Jabber #187 (11-25-2015)
+  </a>
+ </li>
+ <li>
+  <a href="https://changelog.com/184/">
+   Changelog #184 (11-27-2015)
+  </a>
+ </li>
+ <li>
+  <a href="http://softwareengineeringdaily.com/2015/12/29/front-end-javascript-with-evan-you/">
+   Software Engineering Daily (12-29-2015)
+  </a>
+ </li>
+ <li>
+  <a href="https://javascriptair.com/episodes/2016-03-30/">
+   Javascript Air 016 (03-30-2016)
+  </a>
+ </li>
+</ul>
+<h3>
+ Official Examples
+</h3>
+<ul>
+ <li>
+  <a href="http://vuejs.org/guide/">
+   Basic Examples
+  </a>
+ </li>
+ <li>
+  <a href="https://github.com/vuejs/vue/tree/dev/examples/todomvc">
+   Vue.js TodoMVC
+  </a>
+  <ul>
+   <li>
+    <a href="https://github.com/anfelor/TodoMVC-CoffeeScript-and-Vue.js">
+     CoffeeScript Version
+    </a>
+    <sup>
+     &#9733 3, pushed 52 days ago
+    </sup>
+   </li>
+  </ul>
+ </li>
+ <li>
+  <a href="https://github.com/vuejs/vue-hackernews">
+   Vue.js HackerNews Clone
+  </a>
+  <sup>
+   &#9733 897, pushed 56 days ago
+  </sup>
+ </li>
+</ul>
+<h3>
+ Tutorials
+</h3>
+<ul>
+ <li>
+  <a href="https://laracasts.com/series/learning-vue-step-by-step">
+   Vue.js screencasts
+  </a>
+  on Laracasts
+ </li>
+ <li>
+  <a href="http://www.sitepoint.com/whats-new-in-vue-js-1-0/">
+   What's New in Vue.js 1.0
+  </a>
+  on Sitepoint
+ </li>
+ <li>
+  <a href="https://auth0.com/blog/2015/11/13/build-an-app-with-vuejs/">
+   Build an App with Vue.js: From Authentication to Calling an API
+  </a>
+  on Auth0 blog
+ </li>
+ <li>
+  <a href="https://scotch.io/tutorials/create-a-github-file-explorer-using-vue-js">
+   Create a GitHub File Explorer Using Vue.js
+  </a>
+  on Scotch.io
+ </li>
+ <li>
+  <a href="http://vegibit.com/vue-js-tutorial/">
+   Vue.js Tutorial
+  </a>
+  on Vegibit
+ </li>
+ <li>
+  <a href="http://skyronic.com/2015/12/28/vue-project-scratch/">
+   Vue.js build set-up from scratch with webpack, vue-loader and hot reload
+  </a>
+ </li>
+ <li>
+  <a href="http://skyronic.com/2016/01/03/vuex-basics-tutorial/">
+   Vuex basics: Tutorial and explanation
+  </a>
+ </li>
+ <li>
+  <a href="https://www.youtube.com/watch?v=l1KHL-TX3qs">
+   Vuex introduction video - James Browne from London Vue.js Meetup #1
+  </a>
+ </li>
+ <li>
+  <a href="https://laravist.com/series/vue-js-1-0-in-action-series">
+   Vue.js 中文系列视频教程
+  </a>
+  on Laravist
+ </li>
+ <li>
+  <a href="http://coligo.io/vuejs-the-basics/">
+   Vue.js: The Basics
+  </a>
+  on Coligo.io
+ </li>
+ <li>
+  <a href="http://coligo.io/vuejs-components">
+   Practical Intro to Components in Vue.js
+  </a>
+  on Coligo.io
+ </li>
+ <li>
+  <a href="http://craigmckenna.com/develop-a-reactive-invoice-app-using-vue-js/">
+   Develop a Reactive Invoice App using Vue.js
+  </a>
+  on craigmckenna.com
+ </li>
+ <li>
+  <a href="http://coligo.io/vuejs-filters/">
+   Understanding Filters in Vue.js
+  </a>
+  on Coligo.io
+ </li>
+ <li>
+  <a href="https://www.youtube.com/watch?v=TGSJjDahlrQ">
+   Hybrid App Example with Laravel and Vue.js in portuguese
+  </a>
+  by @vedovelli
+ </li>
+ <li>
+  <a href="http://coligo.io/markdown-editor-vuejs/">
+   Creating a Markdown Editor with VueJs and GitHub's API
+  </a>
+  on Coligo.io
+ </li>
+ <li>
+  <a href="http://coligo.io/real-time-analytics-with-nodejs-socketio-vuejs/">
+   Building a Real-Time Web Analytics Dashboard with NodeJs, Socket.io, and VueJs
+  </a>
+  on Coligo.io
+ </li>
+ <li>
+  <a href="http://oguzhan.in/vue-js-ile-uygulama-gelistirme/">
+   Vue.js Introduction Turkish Language
+  </a>
+  on oguzhan.in
+ </li>
+ <li>
+  <a href="https://www.youtube.com/watch?v=IlFk3cyRB0Y&list=PLM-Y_YQmMEqD2EWfWpSbiV3WgShRRW3FE&index=7">
+   Vue.js VideoTutoral Series in Spanish (3-8-2016)
+  </a>
+  on YouTube by Juan Andrés Núñez
+ </li>
+ <li>
+  <a href="http://coligo.io/bookmarking-app-electron-vuejs-firebase/">
+   Building a Bookmarking App with Electron, VueJs, and Firebase
+  </a>
+  on Coligo.io
+ </li>
+</ul>
+<h4>
+ 0.12 and earlier
+</h4>
+<ul>
+ <li>
+  <a href="https://laracasts.com/series/learning-vuejs">
+   Vue.js screencasts
+  </a>
+  on Laracasts
+  <sup>
+   0.12
+  </sup>
+ </li>
+ <li>
+  <a href="https://scotch.io/tutorials/build-an-app-with-vue-js-a-lightweight-alternative-to-angularjs">
+   Build an App with Vue.js
+  </a>
+  on Scotch.io
+  <sup>
+   0.12
+  </sup>
+ </li>
+ <li>
+  <a href="http://www.sitepoint.com/getting-started-with-vue-js/">
+   Getting Started with Vue.js
+  </a>
+  on Sitepoint
+  <sup>
+   0.12
+  </sup>
+ </li>
+ <li>
+  <a href="http://forum.vuejs.org/topic/49/vue-js-video-series-in-portuguese">
+   Vue.js video series in portuguese
+  </a>
+  <sup>
+   0.12
+  </sup>
+ </li>
+ <li>
+  <a href="http://ausite.ru/category/js/vue-js">
+   Vue.js video series in russian
+  </a>
+  on Ausite
+  <sup>
+   0.12
+  </sup>
+ </li>
+ <li>
+  <a href="http://mattsparks.com/a-quick-introduction-to-vue-js/">
+   A Quick Introduction to Vue.js
+  </a>
+  by Matt Sparks
+  <sup>
+   0.12
+  </sup>
+ </li>
+ <li>
+  <a href="https://www.youtube.com/watch?v=QN7l3ydXvx0">
+   Getting Started with Vue.js + vue-router
+  </a>
+  by Michael Calkins
+  <sup>
+   0.12
+  </sup>
+ </li>
+ <li>
+  <a href="http://taha-sh.com/blog/many-js-frameworks-but-vuejs-is-different">
+   Many JS Frameworks but Vue.js Is Different
+  </a>
+  by Taha Shashtari
+  <sup>
+   0.12
+  </sup>
+ </li>
+ <li>
+  <a href="http://fadeit.dk/blog/post/getting-started-with-vuejs-angularjs-perspective">
+   Getting Started with Vue.js - AngularJS perspective
+  </a>
+  by Dan Mindru
+  <sup>
+   0.11
+  </sup>
+ </li>
+</ul>
+<h3>
+ Development Tools
+</h3>
+<ul>
+ <li>
+  <a href="https://github.com/vuejs/vue-cli">
+   vue-cli
+  </a>
+  : official CLI for scaffolding Vue.js projects.
+  <sup>
+   &#9733 565, pushed 10 days ago
+  </sup>
+ </li>
+ <li>
+  <a href="https://github.com/vuejs/vue-loader">
+   vue-loader
+  </a>
+  - Vue component loader for Webpack.
+  <ul>
+   <li>
+    <a href="https://github.com/vuejs/vue-loader-example">
+     vue-loader-example
+    </a>
+    <sup>
+     &#9733 312, pushed 48 days ago
+    </sup>
+   </li>
+  </ul>
+  <sup>
+   &#9733 450, pushed 1 days ago
+  </sup>
+ </li>
+ <li>
+  <a href="https://github.com/vuejs/vueify">
+   vueify
+  </a>
+  - Vue compcomponent transform for Browserify.
+  <ul>
+   <li>
+    <a href="https://github.com/vuejs/vueify-example">
+     vueify-example
+    </a>
+    <sup>
+     &#9733 83, pushed 83 days ago
+    </sup>
+   </li>
+  </ul>
+  <sup>
+   &#9733 408, pushed 3 days ago
+  </sup>
+ </li>
+ <li>
+  <a href="https://github.com/vuejs/vue-devtools">
+   vue-devtools
+  </a>
+  - Chrome devtools extension for debugging Vue applications.
+  <sup>
+   &#9733 583, pushed 10 days ago
+  </sup>
+ </li>
+ <li>
+  <a href="https://github.com/SkewedAspect/grunt-vueify">
+   grunt-vueify
+  </a>
+  - Translate
+  <code>
+   .vue
+  </code>
+  files to pure JavaScript, without using Browserify. (Useful for Electron apps)
+  <sup>
+   &#9733 1, pushed 54 days ago
+  </sup>
+ </li>
+ <li>
+  <a href="https://github.com/paulpflug/vue-compiler">
+   vue-compiler
+  </a>
+  - A simple CLI wrapper around vueify
+  <sup>
+   &#9733 2, pushed 7 days ago
+  </sup>
+ </li>
+ <li>
+  <a href="https://atom.io/packages/vue-autocompile">
+   vue-autocompile
+  </a>
+  - Atom.io package to compile
+  <code>
+   .vue
+  </code>
+  files on save.
+ </li>
+ <li>
+  <a href="https://github.com/paulpflug/vue-dev-server">
+   vue-dev-server
+  </a>
+  - A small webpack-based development server for building standalone
+  <code>
+   vue
+  </code>
+  components
+  <sup>
+   &#9733 3, pushed 42 days ago
+  </sup>
+ </li>
+ <li>
+  <a href="https://github.com/rodzzlessa24/vue-go-cli">
+   vue-go-cli
+  </a>
+  - a CLI tool for scaffolding new projects generating components, services, and mixins.
+  <sup>
+   &#9733 2, pushed 48 days ago
+  </sup>
+ </li>
+ <li>
+  <a href="https://github.com/nblackburn/vue-brunch">
+   brunch-vue
+  </a>
+  - Adds support to Brunch for pre-compiling single file Vue components.
+  <sup>
+   &#9733 2, pushed 44 days ago
+  </sup>
+ </li>
+ <li>
+  <a href="https://github.com/rawcreative/vueify-extract-css">
+   vueify-extract-css
+  </a>
+  - Browserify plugin to extract css from Vueify-compiled single file components to a separate css file.
+  <sup>
+   &#9733 18, pushed 29 days ago
+  </sup>
+ </li>
+ <li>
+  <a href="https://github.com/twiknight/eslint-plugin-vue">
+   eslint-plugin-vue
+  </a>
+  - Eslint plugin for .vue files.
+  <sup>
+   &#9733 20, pushed 21 days ago
+  </sup>
+ </li>
+</ul>
+<h3>
+ Syntax Highlighting
+</h3>
+<ul>
+ <li>
+  <a href="https://github.com/vuejs/vue-syntax-highlight">
+   Sublime Text
+  </a>
+ </li>
+ <li>
+  <a href="https://atom.io/packages/language-vue">
+   Atom
+  </a>
+  by @hedefalk
+ </li>
+ <li>
+  <a href="https://atom.io/packages/language-vue-component">
+   Atom (2)
+  </a>
+  by @CYBAI
+ </li>
+ <li>
+  <a href="https://github.com/posva/vim-vue">
+   Vim
+  </a>
+  by @darthmall and @posva
+  <sup>
+   &#9733 30, pushed 2 days ago
+  </sup>
+ </li>
+ <li>
+  <a href="https://marketplace.visualstudio.com/items/liuji-jim.vue">
+   Visual Studio Code
+  </a>
+  by Jim Liu
+ </li>
+ <li>
+  <a href="https://github.com/pandao/brackets-vue">
+   Brackets
+  </a>
+  by @pandao
+  <sup>
+   &#9733 6, pushed 113 days ago
+  </sup>
+ </li>
+ <li>
+  <a href="https://github.com/henjue/vue-for-idea">
+   IntelliJ IDEA / WebStorm
+  </a>
+  by @henjue
+  <sup>
+   &#9733 135, pushed 28 days ago
+  </sup>
+ </li>
+ <li>
+  <a href="https://github.com/CodeFalling/vue-mode">
+   Emacs
+  </a>
+  by @CodeFalling
+  <sup>
+   &#9733 2, pushed 10 days ago
+  </sup>
+ </li>
+</ul>
+<h3>
+ Snippets
+</h3>
+<ul>
+ <li>
+  <a href="https://atom.io/packages/vue-snippets">
+   vue-snippets
+  </a>
+  for Atom.io by
+  <a href="https://github.com/ealves-pt">
+   @ealves-pt
+  </a>
+ </li>
+</ul>
+<h3>
+ Autocomplete
+</h3>
+<ul>
+ <li>
+  <a href="https://atom.io/packages/vue-autocomplete">
+   vue-autocomplete
+  </a>
+  for Atom.io by
+  <a href="https://github.com/ealves-pt">
+   @ealves-pt
+  </a>
+ </li>
+</ul>
+<h3>
+ Libraries & Plugins
+</h3>
+<ul>
+ <li>
+  <h4>
+   Routing
+  </h4>
+  <ul>
+   <li>
+    <a href="https://github.com/vuejs/vue-router">
+     vue-router
+    </a>
+    - Official router for building SPAs.
+    <sup>
+     1.0 compatible
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/AlexToudic/vue-page">
+     Vue page
+    </a>
+    , a routing system based on pagejs by @AlexToudic
+    <sup>
+     &#9733 15, pushed 247 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/bpierre/vue-lanes">
+     Vue Lanes
+    </a>
+    , an event-based routing system for Vue by @bpierre
+    <sup>
+     &#9733 19, pushed 756 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/ayamflow/vue-route">
+     Vue route
+    </a>
+    , ng-view inspired routes for Vue by @ayamflow
+    <sup>
+     &#9733 70, pushed 258 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/inca/voie">
+     voie
+    </a>
+    — simple router / layout manager inspired by FSMs and ui-router by
+    <a href="https://github.com/inca">
+     Boris Okunskiy
+    </a>
+    <sup>
+     1.0
+    </sup>
+    <sup>
+     &#9733 107, pushed 2 days ago
+    </sup>
+   </li>
+  </ul>
+  <sup>
+   &#9733 1070, pushed 1 days ago
+  </sup>
+ </li>
+ <li>
+  <h4>
+   Ajax/Data
+  </h4>
+  <ul>
+   <li>
+    <a href="https://github.com/vuejs/vue-resource">
+     vue-resource
+    </a>
+    - AJAX/Resource plugin maintained by the
+    <a href="http://pagekit.com/">
+     PageKit
+    </a>
+    team.
+    <sup>
+     1.0 compatible
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/vuejs/vue-async-data">
+     vue-async-data
+    </a>
+    - Async data loading plugin
+    <sup>
+     1.0 compatible
+    </sup>
+    <sup>
+     &#9733 174, pushed 2 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/foxbenjaminfox/vue-async-computed">
+     vue-async-computed
+    </a>
+    - Plugin to support computed properties that are calculated asynchronously. By
+    <a href="https://github.com/foxbenjaminfox">
+     @foxbenjaminfox
+    </a>
+    <sup>
+     &#9733 15, pushed 3 days ago
+    </sup>
+   </li>
+  </ul>
+  <sup>
+   &#9733 1143, pushed 34 days ago
+  </sup>
+ </li>
+ <li>
+  <h4>
+   State Management
+  </h4>
+  <ul>
+   <li>
+    <a href="https://github.com/vuejs/vuex">
+     vuex
+    </a>
+    - Flux/Redux inspired application architecture for Vue.js.
+   </li>
+   <li>
+    <a href="https://github.com/egoist/revue">
+     revue
+    </a>
+    - Redux binding for Vue by @egoist
+   </li>
+   <li>
+    <a href="https://github.com/yang-wei/vue-redux">
+     vue-redux
+    </a>
+    - Redux binding for Vue by @yang-wei
+    <sup>
+     &#9733 74, pushed 75 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/BosNaufal/vue-freeze">
+     vue-freeze
+    </a>
+    - Simple state management whitout bloating API and Concept for Vue by
+    <a href="https://github.com/BosNaufal">
+     @BosNaufal
+    </a>
+    <sup>
+     &#9733 29, pushed 21 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/BosNaufal/vue-simple-store">
+     vue-simple-store
+    </a>
+    - Store Organizer To Simplify Your Stores for Vue By
+    <a href="https://github.com/BosNaufal">
+     @BosNaufal
+    </a>
+    <sup>
+     &#9733 25, pushed 22 days ago
+    </sup>
+   </li>
+  </ul>
+  <sup>
+   &#9733 1184, pushed 1 days ago
+  </sup>
+ </li>
+ <li>
+  <h4>
+   Validation
+  </h4>
+  <ul>
+   <li>
+    <a href="https://github.com/vuejs/vue-validator">
+     vue-validator
+    </a>
+    - Form validation plugin maintained by @kazupon
+    <sup>
+     1.0 compatible
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/xrado/vue-validator">
+     Vue validator
+    </a>
+    by @xrado
+    <sup>
+     &#9733 34, pushed 195 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/fergaldoyle/vue-form">
+     vue-form
+    </a>
+    by @fergaldoyle
+    <sup>
+     1.0 compatible
+    </sup>
+    <sup>
+     &#9733 105, pushed 2 days ago
+    </sup>
+   </li>
+  </ul>
+  <sup>
+   &#9733 533, pushed 0 days ago
+  </sup>
+ </li>
+ <li>
+  <h4>
+   UI Components
+  </h4>
+  <ul>
+   <li>
+    <a href="http://yuche.github.io/vue-strap/">
+     VueStrap
+    </a>
+    , Bootstrap components built with pure Vue.js by @yuche
+    <sup>
+     1.0
+    </sup>
+   </li>
+   <li>
+    <a href="http://morgul.github.io/vueboot/">
+     VueBoot
+    </a>
+    , Bootstrap v4 components by @Morgul
+    <sup>
+     1.0
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/posva/vue-mdl">
+     vue-mdl
+    </a>
+    : Reusable Vue.js components using Material Design Lite. By
+    <a href="https://github.com/posva">
+     @posva
+    </a>
+    <sup>
+     &#9733 282, pushed 4 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/samcrosoft/vue-countup">
+     vue-countup
+    </a>
+    : A Vue.js component for the very interesting
+    <a href="https://inorganik.github.io/countUp.js/">
+     CountUp.js
+    </a>
+    plugin.
+    <sup>
+     1.0 compatible
+    </sup>
+    <sup>
+     &#9733 8, pushed 78 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/hnakamur/vue.tag-editor.js">
+     Vue Tag Editor Component
+    </a>
+    by @hnakamur
+    <sup>
+     &#9733 19, pushed 762 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="http://pespantelis.github.io/vue-crop/">
+     Vue Crop
+    </a>
+   </li>
+   <li>
+    <a href="http://pespantelis.github.io/vue-typeahead/">
+     Vue Typeahead
+    </a>
+   </li>
+   <li>
+    <a href="https://github.com/dgerber/vue-select-js">
+     Typed select component
+    </a>
+    by @dgerber
+    <sup>
+     &#9733 3, pushed 321 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/Haixing-Hu/vue-select">
+     vue-select
+    </a>
+    : A Vue.js component implementing the select control with the
+    <a href="https://github.com/select2/select2">
+     jQuery select2 plugin
+    </a>
+    .  By @Haixing-Hu
+    <sup>
+     &#9733 44, pushed 43 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/Haixing-Hu/vue-html-editor">
+     vue-html-editor
+    </a>
+    : A Vue.js component implementing the HTML editor with the
+    <a href="https://github.com/summernote/summernote">
+     jQuery summernote plugin
+    </a>
+    . By @Haixing-Hu
+    <sup>
+     &#9733 54, pushed 79 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/Haixing-Hu/vue-datetime-picker">
+     vue-datetime-picker
+    </a>
+    : A Vue.js component implementing the datetime picker control using the
+    <a href="https://github.com/Eonasdan/bootstrap-datetimepicker">
+     Eonasdan's bootstrap datetime picker plugin
+    </a>
+    . By @Haixing-Hu
+    <sup>
+     &#9733 54, pushed 17 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/Haixing-Hu/vue-country-select">
+     vue-country-select
+    </a>
+    : A Vue.js component implementing the select control used to select countries. It depends on
+    <a href="https://github.com/Haixing-Hu/vue-select">
+     vue-select
+    </a>
+    and
+    <a href="https://github.com/Haixing-Hu/vue-i18n">
+     vue-i18n
+    </a>
+    . By @Haixing-Hu
+    <sup>
+     &#9733 11, pushed 192 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/dgerber/vue-formidable">
+     Form generation from JSON Schema
+    </a>
+    by @dgerber
+    <sup>
+     &#9733 19, pushed 320 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/ericmcdaniel/vue-panel">
+     vue-panel
+    </a>
+    : A suite of Vue.js components for building Flexbox layouts by @ericmcdaniel
+    <sup>
+     &#9733 36, pushed 112 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/GuillaumeLeclerc/vue-google-maps/">
+     vue-google-maps
+    </a>
+    : A suite of Vue.js components to build reactive Google Maps Applications by @GuillaumeLeclerc
+   </li>
+   <li>
+    <a href="https://github.com/Twiknight/vue-transition">
+     vue-transition
+    </a>
+    : A component to trigger a CSS transition at any time by @Twiknight
+    <sup>
+     &#9733 34, pushed 49 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="http://kzima.github.io/vuestrap-icons/#/icons">
+     SVG icons
+    </a>
+    , SVG sprites in form of a simple
+    <code>
+     <icon>
+    </code>
+    component, by @kzima
+    <sup>
+     1.0
+    </sup>
+   </li>
+   <li>
+    <a href="http://gritcode.github.io/gritcode-components/#/toast">
+     Extra Vuestrap components
+    </a>
+    , more components built with just B4 and Vue.js, by @kzima
+    <sup>
+     1.0
+    </sup>
+   </li>
+   <li>
+    <a href="http://kzima.github.io/vuestrap-base-components/#/accordion">
+     VueStrap Base Components
+    </a>
+    , A complete set of Bootstrap 4 web components built with pure Vue.js, by @kzima
+    <sup>
+     1.0
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/kaorun343/vue-youtube-embed">
+     Vue YouTube Embed
+    </a>
+    : a directive for Vue.js and YouTube by @kaorun343
+    <sup>
+     &#9733 16, pushed 29 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/hilongjw/vue-datepicker">
+     Vue datepicker
+    </a>
+    : calendar and datepicker component with material design for Vue.js  by @hilongjw
+    <sup>
+     &#9733 48, pushed 1 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/Bubblings/vue-date-picker">
+     vue-date-picker
+    </a>
+    : A simple datepicker component for Vue.js by @Bubblings
+    <sup>
+     &#9733 15, pushed 8 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/greyby/vue-spinner">
+     vue-spinner
+    </a>
+    : A collection of loading spinners with Vue.js.
+    <sup>
+     &#9733 129, pushed 54 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/eduardostuart/vue-image-loader">
+     vue-image-loader
+    </a>
+    : Async image loader for Vue.js by @eduardostuart
+    <sup>
+     &#9733 13, pushed 73 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/hilongjw/vue-progressbar">
+     Vue-progressbar
+    </a>
+    : A lightweight progress bar for Vue.js  by @hilongjw
+    <sup>
+     &#9733 35, pushed 73 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/irwansyahwii/Famous-Vue">
+     Famous-Vue
+    </a>
+    : Declarative Famous using Vue
+    <sup>
+     &#9733 10, pushed 64 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/MopTym/vue-waterfall">
+     vue-waterfall
+    </a>
+    : A waterfall layout component for Vue.js by @MopTym
+    <sup>
+     &#9733 204, pushed 54 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/haydenbbickerton/vue-charts">
+     vue-charts
+    </a>
+    : A Google Charts plugin for Vue.js by
+    <a href="https://github.com/haydenbbickerton">
+     @haydenbbickerton
+    </a>
+    <sup>
+     &#9733 17, pushed 15 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/airyland/vux">
+     vux
+    </a>
+    : Mobile web UI Components based on Vue and WeUI
+    <sup>
+     &#9733 1057, pushed 0 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/sagalbot/vue-select">
+     vue-select
+    </a>
+    : Simple component that implements Select2/Chosen style dropdowns with no dependencies
+    <sup>
+     1.0
+    </sup>
+    <sup>
+     &#9733 154, pushed 8 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/hilongjw/vue-slide">
+     Vue-slide
+    </a>
+    : A lightweight slide component for Vue.js  by @hilongjw
+    <sup>
+     &#9733 29, pushed 19 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/CroudSupport/vue-quill">
+     Vue-quill
+    </a>
+    : A Vue component implementing the
+    <a href="https://github.com/quilljs/quill.git">
+     Quill
+    </a>
+    text editor by @brockreece
+    <sup>
+     &#9733 5, pushed 22 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/zxdong262/vue-pagenav">
+     vue-pagenav
+    </a>
+    : A vue pagenav plugin by
+    <a href="https://github.com/zxdong262">
+     @zxdong262
+    </a>
+    <sup>
+     &#9733 6, pushed 4 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/cucygh/vue-calendar">
+     Vue-calendar
+    </a>
+    : A vue calendar component with less code by cucygh
+    <sup>
+     &#9733 1, pushed 23 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="http://appcomponents.org/material-components/">
+     Vue Material Components
+    </a>
+    : Vue.js UI components using
+    <a href="http://materializecss.com/">
+     materializecss.com
+    </a>
+    by mjanys
+   </li>
+   <li>
+    <a href="https://github.com/BosNaufal/vue-autocomplete">
+     vue-autocomplete
+    </a>
+    Autocomplete Component for Vue by
+    <a href="https://github.com/BosNaufal">
+     @BosNaufal
+    </a>
+    <sup>
+     &#9733 22, pushed 94 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/BosNaufal/vue-loading-bar">
+     vue-loading-bar
+    </a>
+    Youtube Like Loading Bar Component for Vue by
+    <a href="https://github.com/BosNaufal">
+     @BosNaufal
+    </a>
+    <sup>
+     &#9733 26, pushed 10 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/Coffcer/vue-bootstrap-modal">
+     vue-bootstrap-modal
+    </a>
+    Bootstrap style modal component for Vue by
+    <a href="https://github.com/Coffcer">
+     @Coffcer
+    </a>
+    <sup>
+     &#9733 5, pushed 3 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/vue-comps">
+     vue-comps
+    </a>
+    : A collection of unstyled and unanimated components (side-nav / modal / collapsible / clusterize / dropdown / resize-handle and other)
+   </li>
+   <li>
+    <a href="https://github.com/paulpflug/vue-materialize">
+     vue-materialize
+    </a>
+    : materializeCss styles and animations for some of
+    <a href="https://github.com/vue-comps">
+     vue-comps
+    </a>
+    <sup>
+     &#9733 22, pushed 1 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/Teddy-Zhu/vue-waves">
+     vue-waves
+    </a>
+    :Click effect inspired by Google's Material Design ,the vue version By @Teddy-Zhu
+    <sup>
+     &#9733 3, pushed 8 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/ratiw/vue-table">
+     vue-table
+    </a>
+    : component that will automatically request (JSON) data from the server and display them nicely in html table with swappable/extensible pagination component. By @ratiw
+    <sup>
+     &#9733 26, pushed 0 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/firework/fire-select">
+     fire-select
+    </a>
+    : Vue component that transforms overwhelming select boxes into something fancy, simple and user-friendly. It is similar to Selectize, Chosen, Select2, etc.
+    <sup>
+     &#9733 26, pushed 1 days ago
+    </sup>
+   </li>
+  </ul>
+ </li>
+ <li>
+  <h4>
+   i18n
+  </h4>
+  <ul>
+   <li>
+    <a href="https://github.com/kazupon/vue-i18n">
+     vue-i18n
+    </a>
+    : Internationalization plugin.
+   </li>
+   <li>
+    <a href="https://github.com/Haixing-Hu/vue-i18n">
+     vue-i18n
+    </a>
+    : A plugin providing a global interface used to localize internationalized messages used in the
+    <sup>
+     &#9733 32, pushed 2 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/sebastian-software/vue-locale">
+     vue-locale
+    </a>
+    : Advanced localization support for VueJS
+    <sup>
+     &#9733 9, pushed 34 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/zxdong262/vue-jade-editor">
+     vue-jade-editor
+    </a>
+    : a online jade(pug) editor plugin by
+    <a href="https://github.com/zxdong262">
+     @zxdong262
+    </a>
+    <sup>
+     &#9733 0, pushed 8 days ago
+    </sup>
+   </li>
+  </ul>
+  <sup>
+   &#9733 164, pushed 1 days ago
+  </sup>
+ </li>
+ <li>
+  <h4>
+   Examples
+  </h4>
+  <ul>
+   <li>
+    <a href="http://forum.vuejs.org/topic/39/starter-application-with-jwt-auth-sample-backend-api">
+     Starter Application with JWT Auth + sample backend API in Laravel
+    </a>
+   </li>
+   <li>
+    <a href="https://github.com/brandonjpierce/node-webkit-boilerplate">
+     Node Webkit + Vue example
+    </a>
+    by @brandonjpierce
+    <sup>
+     &#9733 34, pushed 287 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/superlloyd/VueSamples">
+     Vue Samples
+    </a>
+    by @superlloyd
+    <sup>
+     &#9733 18, pushed 175 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/kazupon/vue-router-hackernews">
+     HackerNews clone with vue.js + vue-router
+    </a>
+    by @kazupon
+    <sup>
+     &#9733 2, pushed 240 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/bradstewart/electron-boilerplate-vue">
+     Electron + Vue example
+    </a>
+    by @bradstewart
+    <sup>
+     &#9733 144, pushed 1 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/inca/voie-example">
+     Single page application example (Vue + Voie)
+    </a>
+    by
+    <a href="https://github.com/inca">
+     Boris Okunskiy
+    </a>
+    <sup>
+     &#9733 30, pushed 108 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/rajabishek/begin">
+     Begin - Task Manager SPA written in Vue + Lumen
+    </a>
+    by
+    <a href="https://github.com/rajabishek">
+     Raj Abishek
+    </a>
+    <sup>
+     &#9733 10, pushed 25 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/BosNaufal/vue-mini-shop">
+     Vue Mini Shop
+    </a>
+    by
+    <a href="https://github.com/BosNaufal">
+     BosNaufal
+    </a>
+    <sup>
+     &#9733 10, pushed 22 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/mul14/vue-soundcloud">
+     Vue SoundCloud
+    </a>
+    by
+    <a href="https://github.com/mul14">
+     mul14
+    </a>
+    <sup>
+     &#9733 11, pushed 0 days ago
+    </sup>
+   </li>
+  </ul>
+ </li>
+ <li>
+  <h4>
+   Boilerplates
+  </h4>
+  <ul>
+   <li>
+    <a href="https://github.com/kazupon/vue-plugin-boilerplate">
+     Boilerplate for Vue.js plugin
+    </a>
+    by @kazupon
+   </li>
+   <li>
+    <a href="https://github.com/rodzzlessa24/vue-electron">
+     Boilerplate for Vue.js & Atom Electron
+    </a>
+    by @rodzzlessa24
+    <sup>
+     &#9733 33, pushed 14 days ago
+    </sup>
+   </li>
+  </ul>
+  <sup>
+   &#9733 16, pushed 52 days ago
+  </sup>
+ </li>
+ <li>
+  <h4>
+   Scaffolding
+  </h4>
+  <ul>
+   <li>
+    <a href="https://github.com/vuejs/vue-cli">
+     vue-cli
+    </a>
+    : official CLI for scaffolding Vue.js projects.
+   </li>
+   <li>
+    <a href="https://github.com/BirdEggegg/generator-vue">
+     Vue generator
+    </a>
+    : a simple yeoman generator for Vue by @BirdEggegg
+   </li>
+   <li>
+    <a href="https://github.com/jfelsinger/generator-venm">
+     VENM stack yeoman generator
+    </a>
+    by @jfelsinger
+    <sup>
+     &#9733 35, pushed 121 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/mustardamus/generator-grail">
+     Grail Yeoman Generator
+    </a>
+    : a advanced yeoman generator for a modern modular one page web app, extendable with Vue.js alongside other nice tools
+    <sup>
+     &#9733 9, pushed 167 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/egoist/vuepack">
+     VuePack
+    </a>
+    : A modern starter for Vue and Webpack by @egoist
+    <sup>
+     &#9733 157, pushed 6 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/rodzzlessa24/vue-webgulp">
+     VueWebgulp
+    </a>
+    : A skeleton app using Vuejs, Gulp, and Webpack by @rodzzlessa24
+    <sup>
+     &#9733 31, pushed 30 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/scottbedard/oc-vuetober-theme">
+     Vuetober
+    </a>
+    : SPA scaffolding for October CMS
+    <sup>
+     &#9733 21, pushed 26 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/rodzzlessa24/vue-go-cli">
+     vue-go-cli
+    </a>
+    - a CLI tool for scaffolding new projects generating components, services, and mixins.
+   </li>
+   <li>
+    <a href="https://github.com/nblackburn/brunch-with-vue">
+     Brunch with Vue
+    </a>
+    - A skeleton application utilizing vue, vuex, vue-resource and vue-router.
+    <sup>
+     &#9733 9, pushed 37 days ago
+    </sup>
+   </li>
+  </ul>
+ </li>
+ <li>
+  <h4>
+   Integrations
+  </h4>
+  <ul>
+   <li>
+    <a href="https://github.com/zhouzhuojie/meteor-vue">
+     Vue for Meteor
+    </a>
+    by @zhouzhuojie
+   </li>
+   <li>
+    <a href="https://github.com/fancellu/scalajs-vue">
+     ScalaJS bindings for Vue.js
+    </a>
+    by @fancellu
+    <sup>
+     &#9733 22, pushed 177 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/Socketize/vue.js-plugin">
+     Socketize Backend
+    </a>
+    : Sync your model data to Socketize backend automatically. By
+    <a href="https://github.com/Socketize">
+     @Socketize
+    </a>
+    <sup>
+     &#9733 6, pushed 118 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/Grottolabs/vue-meteor-data">
+     Vue-Meteor-Data
+    </a>
+    Two-way-reactivity mixin for Vue and Meteor by @JakobRosenberg
+    <sup>
+     &#9733 12, pushed 3 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/kaorun343/vue-property-decorator">
+     Vue Proerty Decorator
+    </a>
+    : Property Decorators for Vue.js by @kaorun343
+    <sup>
+     &#9733 7, pushed 87 days ago
+    </sup>
+   </li>
+  </ul>
+  <sup>
+   &#9733 74, pushed 114 days ago
+  </sup>
+ </li>
+ <li>
+  <h4>
+   General Plugins/Directives
+  </h4>
+  <ul>
+   <li>
+    <a href="https://github.com/vuejs/vue-element">
+     vue-element
+    </a>
+    : Register real custom elements with Vue.
+   </li>
+   <li>
+    <a href="https://github.com/vuejs/vue-touch">
+     vue-touch
+    </a>
+    : Hammer.js wrapper directives for touch gestures. (Updated for 1.0!)
+    <sup>
+     &#9733 217, pushed 15 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/vuejs/vue-animated-list">
+     vue-animated-list
+    </a>
+    : A Vue.js plugin for easily animating
+    <code>
+     v-for
+    </code>
+    rendered lists.
+    <sup>
+     &#9733 85, pushed 63 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/lithiumjake/vue-placeholders">
+     Vue placeholder directives
+    </a>
+    by @lithiumjake
+    <sup>
+     &#9733 46, pushed 793 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/holic/vue-viewport">
+     Vue in viewport detection directive
+    </a>
+    by @holic
+    <sup>
+     &#9733 27, pushed 666 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/kewah/vue-once">
+     Vue once directive
+    </a>
+    by @kewah
+    <sup>
+     &#9733 10, pushed 498 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/KyleRoss/vue-modified">
+     Vue Modified Directive
+    </a>
+    by @KyleRoss
+    <sup>
+     &#9733 10, pushed 434 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/mark-hahn/vue-keep-scroll">
+     Maintain scroll position on page changes
+    </a>
+    by @mark-hahn
+    <sup>
+     &#9733 16, pushed 30 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/Haixing-Hu/vue-titlecase">
+     vue-titlecase
+    </a>
+    : A plugin providing a global filter and an instance method used to titlecase (different from capitalize) strings. By @Haixing-Hu
+    <sup>
+     &#9733 9, pushed 164 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/Haixing-Hu/vue-format">
+     vue-format
+    </a>
+    : A plugin providing a global filter and an instance method used to format messages with arguments.  By @Haixing-Hu
+application.  By @Haixing-Hu
+    <sup>
+     &#9733 9, pushed 62 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/simplesmiler/vue-clickaway">
+     vue-clickaway
+    </a>
+    : Assign a method to be called whenever user clicks away from the element. By @simplesmiler
+    <sup>
+     &#9733 33, pushed 118 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/simplesmiler/vue-focus">
+     vue-focus
+    </a>
+    : Manage input focus in the MVVM-friendly way. By @simplesmiler
+    <sup>
+     &#9733 31, pushed 118 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/rhyzx/vue-transfer-dom">
+     vue-transfer-dom
+    </a>
+    : Transfer DOM to another location. by @rhyzx
+    <sup>
+     &#9733 17, pushed 31 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/hilongjw/vue-lazyload">
+     vue-lazyload
+    </a>
+    : lazyloading images. by @hilongjw
+    <sup>
+     &#9733 59, pushed 5 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/didierfranc/v-touch">
+     v-touch
+    </a>
+    : The easiest way to use Hammer.js with Vue.js and use touch gestures. by
+    <a href="https://github.com/didierfranc">
+     @didierfranc
+    </a>
+    <sup>
+     Vue.js 1.x
+    </sup>
+    <sup>
+     &#9733 5, pushed 74 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/paulpflug/vue-mixins">
+     vue-mixins
+    </a>
+    A collection of mixins aimed to replace some jQuery functionality
+    <sup>
+     &#9733 9, pushed 8 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/paulpflug/vue-filters">
+     vue-filters
+    </a>
+    A collection of filters
+    <sup>
+     &#9733 2, pushed 47 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/rascada/vue-round-filter">
+     vue-round-filter
+    </a>
+    filter for rounding with whichever decimal accuracy
+    <sup>
+     &#9733 0, pushed 65 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/TahaSh/vue-paginate">
+     vue-paginate
+    </a>
+    A simple plugin to use pagination in vue.js. by @TahaSh
+    <sup>
+     &#9733 40, pushed 18 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/rpkilby/vue-super">
+     vue-super
+    </a>
+    A simple plugin to call methods on parent components.
+    <sup>
+     &#9733 5, pushed 50 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/arexio/vue-deepstream">
+     vue-deepstream
+    </a>
+    Plugin to simplify event subscription and event trigger when using
+    <a href="https://deepstream.io/">
+     deepstream.io
+    </a>
+    <sup>
+     &#9733 6, pushed 3 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/Coffcer/vue-plain">
+     vue-plain
+    </a>
+    Plugin to get plain object from vue getter/setter object.
+    <sup>
+     &#9733 1, pushed 16 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/BosNaufal/vue-calc-input">
+     vue-calc-input
+    </a>
+    Vue directive to make a calculator input behavior by
+    <a href="https://github.com/BosNaufal">
+     @BosNaufal
+    </a>
+    <sup>
+     &#9733 1, pushed 40 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/BosNaufal/vue-move-dom">
+     vue-move-dom
+    </a>
+    Vue Directive to move the DOM without losing all the VM data, event, etc. by
+    <a href="https://github.com/BosNaufal">
+     @BosNaufal
+    </a>
+    <sup>
+     &#9733 1, pushed 40 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/haydenbbickerton/vue-animate">
+     vue-animate
+    </a>
+    : Use
+    <a href="https://github.com/daneden/animate.css" title="Animate.css">
+     Animate.css
+    </a>
+    with Vue.js transitions. By
+    <a href="https://github.com/haydenbbickerton">
+     @haydenbbickerton
+    </a>
+    <sup>
+     &#9733 10, pushed 12 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/sagalbot/vue-sortable">
+     vue-sortable
+    </a>
+    : A lightweight directive for reorderable drag-and-drop lists using
+    <a href="https://github.com/RubaXa/Sortable">
+     RubaXa/Sortable
+    </a>
+    . By
+    <a href="https://github.com/sagalbot">
+     @sagalbot
+    </a>
+    <sup>
+     &#9733 19, pushed 14 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/Coffcer/vue-loading">
+     vue-loading
+    </a>
+    : Vue directive, show loading block in any element. By
+    <a href="https://github.com/Coffcer">
+     @coffcer
+    </a>
+    <sup>
+     &#9733 13, pushed 10 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/mlyknown/vue-gesture">
+     vue-gesture
+    </a>
+    :touch events plugin for Vue.js.You can v-gesture directive,and directive auguments can use a tap, swipe, etc.
+    <sup>
+     &#9733 6, pushed 15 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/JALBAA/vue-lazyload-img">
+     vue-lazyload-img
+    </a>
+    another image lazyload plugin for Vue, especially optimized for mobile browser. By
+    <a href="https://github.com/JALBAA">
+     @JALBAA
+    </a>
+    <sup>
+     &#9733 5, pushed 7 days ago
+    </sup>
+   </li>
+  </ul>
+  <sup>
+   &#9733 72, pushed 326 days ago
+  </sup>
+ </li>
+ <li>
+  <h4>
+   Talks
+  </h4>
+  <ul>
+   <li>
+    <a href="http://www.slideshare.net/coulix/vuejs-testing">
+     Vue unit tests
+    </a>
+    by
+    <a href="https://github.com/coulix">
+     coulix
+    </a>
+   </li>
+  </ul>
+ </li>
+</ul>
+<h3>
+ Projects Using Vue.js
+</h3>
+<ul>
+ <li>
+  <h4>
+   Open Source
+  </h4>
+  <ul>
+   <li>
+    <a href="http://pagekit.com/">
+     PageKit
+    </a>
+    <sup>
+     <a href="https://github.com/pagekit/pagekit">
+      [Source]
+     </a>
+    </sup>
+   </li>
+   <li>
+    <a href="http://p5js.org/download/">
+     p5.js editor
+    </a>
+    <sup>
+     <a href="https://github.com/processing/p5.js-editor">
+      [Source]
+     </a>
+    </sup>
+   </li>
+   <li>
+    <a href="https://python-china.org">
+     Python China
+    </a>
+    <sup>
+     <a href="https://github.com/zerqu/qingcheng">
+      [Source]
+     </a>
+    </sup>
+   </li>
+   <li>
+    <a href="http://npmcharts.com">
+     npmcharts.com
+    </a>
+    <sup>
+     <a href="https://github.com/cheapsteak/npmcharts.com">
+      [Source]
+     </a>
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/jiyinyiyong/todolist">
+     Todolist
+    </a>
+    by @jiyinyiyong
+   </li>
+   <li>
+    <a href="https://github.com/thelinuxlich/vue-dashing-js">
+     Dashboard framework
+    </a>
+    by @thelinuxlich
+    <sup>
+     &#9733 40, pushed 211 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/sapjax/fewords">
+     a simple notepad
+    </a>
+    <sup>
+     &#9733 43, pushed 152 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/ilyashubin/FilterBlend">
+     FilterBlend
+    </a>
+    : CSS blend modes and filters playground by @ilyashubin
+    <sup>
+     &#9733 135, pushed 79 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="http://koel.phanan.net">
+     Koel
+    </a>
+    : Music streaming server
+   </li>
+   <li>
+    <a href="https://chrome.google.com/webstore/detail/ikhdkkncnoglghljlkmcimlnlhkeamad">
+     Selection Translator
+    </a>
+    <sup>
+     <a href="https://github.com/lmk123/crx-selection-translate">
+      [Source]
+     </a>
+    </sup>
+    A Chrome Extension let browse any language websites has never been easier.
+   </li>
+   <li>
+    <a href="https://oldj.github.io/SwitchHosts/">
+     SwitchHosts
+    </a>
+    <sup>
+     <a href="https://github.com/oldj/SwitchHosts">
+      [Source]
+     </a>
+    </sup>
+    Switch hosts quickly.
+   </li>
+   <li>
+    <a href="https://github.com/mrgodhani/rss-reader">
+     RSS Reader
+    </a>
+    Simple RSS Reader made using atom electron and vue.js.
+    <sup>
+     &#9733 136, pushed 33 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/Zhangdroid/Gokotta">
+     Gokotta
+    </a>
+    : A simple music player built by electron and vue.
+    <sup>
+     &#9733 121, pushed 27 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/Kocisov/coffeebreak">
+     Coffeebreak
+    </a>
+    Tool for live editing CSS components
+    <sup>
+     &#9733 38, pushed 38 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://chrome.google.com/webstore/detail/blcmlhpbpimcnifnkgkfjhhmoolbidik">
+     BaiduHui: Push Notification - 百度惠：实时推送优惠
+    </a>
+    <sup>
+     <a href="https://github.com/DanielZhu/Magnet-baiduhui-chrome-extension">
+      [Source]
+     </a>
+    </sup>
+    A Chrome Extension allows user use Baidu-Hui services and recieves the push notification about the latest discount infos.
+   </li>
+  </ul>
+ </li>
+ <li>
+  <h4>
+   Apps/Websites
+  </h4>
+  <ul>
+   <li>
+    <a href="https://spark.laravel.com/">
+     Laravel Spark
+    </a>
+   </li>
+   <li>
+    <a href="https://video.vice.com/">
+     Vice Video
+    </a>
+   </li>
+   <li>
+    <a href="https://www.formlets.com">
+     Formlets
+    </a>
+   </li>
+   <li>
+    <a href="https://laracasts.com">
+     Laracasts
+    </a>
+   </li>
+   <li>
+    <a href="https://register.sainsburysentertainment.co.uk/">
+     Sainsbury's Entertainment onboarding platform
+    </a>
+   </li>
+   <li>
+    <a href="https://cuusoo.com">
+     CUUSOO
+    </a>
+   </li>
+   <li>
+    <a href="https://esa.io/">
+     esa.io
+    </a>
+   </li>
+   <li>
+    <a href="http://n1.ru">
+     N1.ru
+    </a>
+   </li>
+   <li>
+    <a href="http://gold.xitu.io">
+     稀土掘金
+    </a>
+   </li>
+   <li>
+    <a href="http://www.prague-airport.com/">
+     Prague Airport
+    </a>
+   </li>
+   <li>
+    <a href="https://www.expressionery.com">
+     Expressionery
+    </a>
+   </li>
+   <li>
+    <a href="http://bt.workswell.com.au">
+     BUYIT
+    </a>
+    by @
+    <a href="http://workswell.com.au">
+     Workswell Australia
+    </a>
+   </li>
+   <li>
+    <a href="http://corentinbac.com/">
+     Portfolio Site
+    </a>
+    by Corentin Bac
+   </li>
+   <li>
+    <a href="https://play.google.com/store/apps/details?id=uk.co.dixons.compareprices&hl=en">
+     Compare Prices by Currys & PCWorld
+    </a>
+   </li>
+   <li>
+    <a href="https://grammarly.com/">
+     Grammarly
+    </a>
+    mistake-free writing service
+   </li>
+   <li>
+    <a href="https://laravist.com/">
+     Laravist
+    </a>
+   </li>
+   <li>
+    <a href="https://atiiv.com">
+     Atiiv
+    </a>
+    An app aimed for personal trainers and their clients.
+   </li>
+   <li>
+    <a href="http://v2.statamic.com">
+     Statamic
+    </a>
+   </li>
+   <li>
+    <a href="http://embalses.azurewebsites.net/">
+     Embalses!
+    </a>
+    A tool to report water dam level using the U.S. Geological Survey database.
+   </li>
+   <li>
+    <a href="http://clem.travelmap.fr">
+     TravelMap
+    </a>
+    A simple way for travellers to create a blog based on a Map
+   </li>
+   <li>
+    <a href="http://movienote.org">
+     movienote.org
+    </a>
+    A app which help users maintaining a list about what movie they have watched.
+   </li>
+   <li>
+    <a href="https://propercloth.com/design-a-shirt">
+     Proper Cloth Shirt Builder
+    </a>
+    Custom shirt builder
+   </li>
+   <li>
+    <a href="https://github.com/julesbou/checkit">
+     CheckIt
+    </a>
+    <sup>
+     &#9733 0, pushed 17 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://github.com/Mati365/reddit-news">
+     Reddit News
+    </a>
+    A browser extension which show notifications and news from reddit
+    <sup>
+     &#9733 27, pushed 14 days ago
+    </sup>
+   </li>
+   <li>
+    <a href="https://www.powerpuffyourself.com/">
+     Powerpuff Yourself by Cartoon Networks
+    </a>
+   </li>
+   <li>
+    <a href="https://app.xiaotaojiang.com/">
+     小桃酱
+    </a>
+   </li>
+  </ul>
+ </li>
+ <li>
+  <h4>
+   Interactive Experiences
+  </h4>
+  <ul>
+   <li>
+    <a href="https://newsfeed.fb.com/">
+     Facebook NewsFeed
+    </a>
+   </li>
+   <li>
+    <a href="https://adblitz.withyoutube.com/#!/advertisers">
+     YouTube AdBlitz 2016
+    </a>
+   </li>
+   <li>
+    <a href="http://bloodsweatandtools.discovery.ca/gamebench/">
+     Blood, Sweat and Tools
+    </a>
+    - by Jam3, led by @cheapsteak
+   </li>
+   <li>
+    <a href="http://omnisense.net">
+     Omnisense Experience
+    </a>
+    -
+    <em>
+     Awwwards & FWA SOTD, FWA Cutting Edge. Awwwards SOTM nominee.
+    </em>
+   </li>
+   <li>
+    <a href="https://danslapeaudelours.canalplus.fr/en/">
+     Being the Bear
+    </a>
+    -
+    <em>
+     Awwwards & FWA SOTD, FWA Cutting Edge, Awwwards SOTM nominee.
+    </em>
+   </li>
+   <li>
+    <a href="http://www.starexperience.fr/">
+     Heineken Star Experience
+    </a>
+    -
+    <em>
+     FWA SOTD.
+    </em>
+   </li>
+   <li>
+    <a href="http://louisansa.com">
+     Louis Ansa Website (portfolio)
+    </a>
+    -
+    <em>
+     Awwwards SOTD, FWA nominee.
+    </em>
+   </li>
+   <li>
+    <a href="http://www.digitalforallnow.com/en/experience">
+     Digital For All
+    </a>
+   </li>
+   <li>
+    <a href="http://www.djeco.com/en">
+     Djeco.com
+    </a>
+   </li>
+  </ul>
+ </li>
+ <li>
+  <h4>
+   Enterprise Usage
+  </h4>
+  <ul>
+   <li>
+    Alibaba
+   </li>
+   <li>
+    Baidu
+   </li>
+   <li>
+    Sina Weibo
+   </li>
+   <li>
+    Xiaomi
+   </li>
+   <li>
+    Ele.me
+   </li>
+   <li>
+    Optimizely
+   </li>
+   <li>
+    Expedia
+   </li>
+   <li>
+    UCWeb
+   </li>
+   <li>
+    Line
+   </li>
+   <li>
+    Nintendo
+   </li>
+   <li>
+    Celtra
+   </li>
+   <li>
+    Sainsbury's
+   </li>
+   <li>
+    <a href="https://arex.io/">
+     AREX
+    </a>
+   </li>
+  </ul>
+ </li>
+</ul>
+<h2>
+ License
+</h2>
+<p>
+ <a href="https://creativecommons.org/publicdomain/zero/1.0/">
+  <img alt="CC0" src="https://i.creativecommons.org/p/zero/1.0/88x31.png"/>
+ </a>
+</p>


### PR DESCRIPTION
I created a separate file that attach repo info (stars count, and last pushed date) for each GitHub repositories included in README.md. It will help users quickly get the basic info of a certain repo.

I can update the file regularly (e.g. daily, weekly) or as needed.

View the file directly at (for format is a little off because of pandoc generated .md):
https://github.com/chaconnewu/awesome-vue/blob/master/awesome_vue_with_repo_info.md