### PR TITLE
Add Statamic

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@
   - [Grammarly](https://grammarly.com/) mistake-free writing service
   - [Laravist](https://laravist.com/)
   - [Atiiv](https://atiiv.com) An app aimed for personal trainers and their clients.
+  - [Statamic](https://statamic.com)
   - [Embalses!](http://embalses.azurewebsites.net/) A tool to report water dam level using the U.S. Geological Survey database.
   - [TravelMap](http://clem.travelmap.fr) A simple way for travellers to create a blog based on a Map
   - [movienote.org](http://movienote.org) A app which help users maintaining a list about what movie they have watched.


### PR DESCRIPTION
In [this commit](https://github.com/vuejs/awesome-vue/commit/c6f7d376f724ff3bd636a7ece847f2e939c9904d) Statamic was removed because the URL was 404ing. When we moved out of beta, we moved from the subdomain to main URL.

Just adding the link back where it originally was.