### PR TITLE
Add vue-settler to scaffold section

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,6 +499,7 @@
   - [Vuetober ★26](https://github.com/scottbedard/oc-vuetober-theme): SPA scaffolding for October CMS
   - [Brunch with Vue ★20](https://github.com/nblackburn/brunch-with-vue) - A skeleton application utilizing vue, vuex, vue-resource and vue-router.
   - [vuex-horizon-scaffold ★12](https://github.com/kylestlb/vuex-horizon-scaffold) - A scaffold with vuex and horizon.io, hooked up to the vue-cli webpack build.
+  - [vue-settler](https://github.com/weavingbird/vue-settler) A Vue 2.0 SPA starter for vue cli based on the official vue webpack template. It comes with [vue-router](https://github.com/vuejs/vue-router), [vuex](https://github.com/vuejs/vuex), [Stylus](https://github.com/stylus/stylus), [axios](https://github.com/mzabriskie/axios) and [LostGrid](https://github.com/peterramsing/lost) already configured and ready to go.
 
 - #### Integrations
 


### PR DESCRIPTION
A Vue 2.0 SPA starter for vue cli based on the official vue webpack template. It comes with [vue-router], [vuex], [Stylus], [axios] and [LostGrid] already configured and ready to go.