### PR TITLE
Adding vuefire-quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,7 +537,8 @@ vue-router 2.0, vue-infinite-scroll 2.0, vue-progressbar 2.0 by [TIGERB](https:/
   - [**App example with JWT Authentication**](https://github.com/Angarsk8/phoenix_vuejs_authentication_example) developed with [**Phoenix Framework**](http://phoenixframework.org), **Vue** and **Vue Router** ([_**demo**_](https://phoenix-vue-auth.herokuapp.com)) by [@Angarsk8](https://github.com/Angarsk8)
   - [Sample CRUD app with router in Vue 2.0](https://github.com/shershen08/vue.js-v2-crud-application) by [@shershen08](https://github.com/shershen08)
   - [ASP.NET Core Vue.js server-side rendering sample](https://github.com/mgyongyosi/VuejsSSRSample) by [@mgyongyosi](https://github.com/mgyongyosi)
-
+  - [vuefire-quickstart](https://github.com/sejr/vuefire-quickstart)[![Express Vue Stars](https://img.shields.io/github/stars/sejr/vuefire-quickstart.svg?style=social&label=Star&maxAge=2592000)](https://github.com/sejr/vuefire-quickstart) Documented Firebase integration w/ webpack and eslint.
+  
 - #### Boilerplates
 
   - [Boilerplate for Vue.js plugin  ★26](https://github.com/kazupon/vue-plugin-boilerplate) by @kazupon <sup>vue-cli compatible</sup>

--- a/README.md
+++ b/README.md
@@ -537,7 +537,7 @@ vue-router 2.0, vue-infinite-scroll 2.0, vue-progressbar 2.0 by [TIGERB](https:/
   - [**App example with JWT Authentication**](https://github.com/Angarsk8/phoenix_vuejs_authentication_example) developed with [**Phoenix Framework**](http://phoenixframework.org), **Vue** and **Vue Router** ([_**demo**_](https://phoenix-vue-auth.herokuapp.com)) by [@Angarsk8](https://github.com/Angarsk8)
   - [Sample CRUD app with router in Vue 2.0](https://github.com/shershen08/vue.js-v2-crud-application) by [@shershen08](https://github.com/shershen08)
   - [ASP.NET Core Vue.js server-side rendering sample](https://github.com/mgyongyosi/VuejsSSRSample) by [@mgyongyosi](https://github.com/mgyongyosi)
-  - [vuefire-quickstart](https://github.com/sejr/vuefire-quickstart)[![Express Vue Stars](https://img.shields.io/github/stars/sejr/vuefire-quickstart.svg?style=social&label=Star&maxAge=2592000)](https://github.com/sejr/vuefire-quickstart) Documented Firebase integration w/ webpack and eslint.
+  - [**vuefire-quickstart**](https://github.com/sejr/vuefire-quickstart) — [![Express Vue Stars](https://img.shields.io/github/stars/sejr/vuefire-quickstart.svg?style=social&label=Star&maxAge=2592000)](https://github.com/sejr/vuefire-quickstart) Documented Firebase integration w/ webpack and eslint, by @sejr.
   
 - #### Boilerplates
 

--- a/README.md
+++ b/README.md
@@ -537,7 +537,7 @@ vue-router 2.0, vue-infinite-scroll 2.0, vue-progressbar 2.0 by [TIGERB](https:/
   - [**App example with JWT Authentication**](https://github.com/Angarsk8/phoenix_vuejs_authentication_example) developed with [**Phoenix Framework**](http://phoenixframework.org), **Vue** and **Vue Router** ([_**demo**_](https://phoenix-vue-auth.herokuapp.com)) by [@Angarsk8](https://github.com/Angarsk8)
   - [Sample CRUD app with router in Vue 2.0](https://github.com/shershen08/vue.js-v2-crud-application) by [@shershen08](https://github.com/shershen08)
   - [ASP.NET Core Vue.js server-side rendering sample](https://github.com/mgyongyosi/VuejsSSRSample) by [@mgyongyosi](https://github.com/mgyongyosi)
-  - [**vuefire-quickstart**](https://github.com/sejr/vuefire-quickstart) — [![Express Vue Stars](https://img.shields.io/github/stars/sejr/vuefire-quickstart.svg?style=social&label=Star&maxAge=2592000)](https://github.com/sejr/vuefire-quickstart) Documented Firebase integration w/ webpack and eslint, by @sejr.
+  - [**vuefire-quickstart**](https://github.com/sejr/vuefire-quickstart) - [![Express Vue Stars](https://img.shields.io/github/stars/sejr/vuefire-quickstart.svg?style=social&label=Star&maxAge=2592000)](https://github.com/sejr/vuefire-quickstart) - Documented Firebase integration w/ webpack and eslint, by [@sejr](https://github.com/sejr).
   
 - #### Boilerplates
 

--- a/awesome_vue_with_repo_info.md
+++ b/awesome_vue_with_repo_info.md
@@ -1510,6 +1510,22 @@
      &#9733 11, pushed 0 days ago
     </sup>
    </li>
+   <li>
+    <strong>
+     <a href="https://github.com/sejr/vuefire-quickstart/">vuefire-quickstart</a> 
+     <!-- Place this tag where you want the button to render. -->
+     <a class="github-button"
+        href="https://github.com/sejr/vuefire-quickstart"
+        data-icon="octicon-star"
+        data-style="mega"
+        data-count-href="/sejr/vuefire-quickstart/stargazers"
+        data-count-api="/repos/sejr/vuefire-quickstart#stargazers_count"
+        data-count-aria-label="# stargazers on GitHub"
+        aria-label="Star sejr/vuefire-quickstart on GitHub">Star</a>
+        well-documented Firebase integration w/ webpack and eslint,
+        by <a href="https://github.com/sejr">@sejr</a>
+    </strong>
+   </li>
   </ul>
  </li>
  <li>


### PR DESCRIPTION
**vuefire-quickstart** aims to be a quick way for Vue developers to get up and running with a Firebase instance. The comments provided in the component files aim to serve as a supplement to the Vue.js documentation.