### PR TITLE
Command line script to list possibly outdated repos from README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/bin/list_outdated.js
+++ b/bin/list_outdated.js
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+var fs = require('fs');
+var path = require('path');
+var _ = require('lodash');
+var gh = require('github-url-to-object')
+var GitHubApi = require("github");
+
+var githubUrlRegex = /https:\/\/github\.com\/[^ )]+/g
+
+var github = initGithubApi('812ad10eda43f637dd3a098900870b36f6a94ddf');
+
+var filePath = path.join(__dirname, '../README.md');
+
+var lines = fs.readFileSync(
+  filePath,
+  {encoding: 'utf-8'}
+).toString().split('\n');
+
+var linesWithRepos = _.chain(lines)
+  // store index along with lines
+  .map(function(line, index, collection){
+    return {
+      content: line,
+      index: index
+    };
+  })
+  // only keep lines with github URLs
+  .filter(function(line, index, collection) {
+      var matches = line.content.match(githubUrlRegex);
+      if (matches && matches.length) {
+        line.matches = matches;
+        return true;
+      }
+      return false;
+  })
+  // parse github URLs to objects and send API request
+  .map(function(line){
+    line.matches = _.chain(line.matches)
+      .map(function (match) {
+        return { match: match, info: gh(match) };
+      })
+      .filter(function(match){
+        return match.info != null;
+      })
+      .map(function(match){
+        var request = {
+          owner: match.info.user,
+          repo: match.info.repo,
+          per_page: 1,page: 1
+        };
+        var range = new Date(new Date().setFullYear(new Date().getFullYear() - 2))
+        github.repos.getCommits(request)
+          .then(outdatedHandler(match.info, line.index, line.content, range))
+          .catch(console.error);
+        return match;
+      }).value();
+    return line;
+  })
+  .value();
+
+function outdatedHandler(githubInfo, lineIndex, line, compareDate) {
+  return function (response) {
+    var lastCommitDate = new Date(response[0].commit.author.date);
+    if(lastCommitDate < compareDate){
+      console.log("The last commit of " + githubInfo.https_url + " was: " + lastCommitDate);
+      console.log("line " + (lineIndex + 1) + ": " + line );
+      console.log('\n');
+    }
+  };
+}
+
+
+function initGithubApi(token) {
+  var github = new GitHubApi({
+      debug: false,
+      protocol: "https",
+      host: "api.github.com",
+      headers: {
+          "user-agent": "awesome-vue-repo-checker"
+      },
+      timeout: 30000
+  });
+
+  // without auth token we can still query, but the rate limit is much lower
+  if(token) {
+    github.authenticate({
+      type: "token",
+      token: token
+    })
+  }
+
+  return github;
+}

--- a/bin/list_outdated.js
+++ b/bin/list_outdated.js
@@ -1,77 +1,106 @@
 #!/usr/bin/env node
-var fs = require('fs');
-var path = require('path');
-var _ = require('lodash');
-var gh = require('github-url-to-object')
-var GitHubApi = require("github");
+const fs = require('fs');
+const path = require('path');
+const gh = require('github-url-to-object')
+const GitHubApi = require("github");
+const program = require('commander');
 
-var githubUrlRegex = /https:\/\/github\.com\/[^ )]+/g
+/**
+ * Command line utility that can be used as an indicator to find repositories in README.md that are
+ * not maintained anymore.
+ *
+ * The tool queries the Github API for the last commit date of the referenced repositories and
+ * prints the date, line and line number of the ones older than some defined date.
+ */
+program
+    .version('0.0.1')
+    .usage('[options]')
+    .option('--token [token]', 'Github token from https://github.com/settings/tokens')
+    .option('--threshold [months]', 'The number of months to used as the threshold for outdated repositories. Defaults to 18.', parseInt)
+    .parse(process.argv);
 
-var github = initGithubApi('812ad10eda43f637dd3a098900870b36f6a94ddf');
+if(!program.token || program.token === true) {
+  console.log("No Github token provided. To avoid hitting the rate limit, you need to generate a token at https://github.com/settings/tokens and provide it with the --token option.")
+  console.log("Continuing without token.")
+  program.token = null
+}
 
-var filePath = path.join(__dirname, '../README.md');
+let monthsAgo = 18;
+if(program.threshold !== true && program.threshold){
+  monthsAgo = program.threshold;
+}
+const thresholdDate = new Date(new Date().setMonth(new Date().getMonth() - monthsAgo))
+console.log("Using " + thresholdDate + " as the threshold date.")
 
-var lines = fs.readFileSync(
-  filePath,
-  {encoding: 'utf-8'}
-).toString().split('\n');
+const githubUrlRegex = /https:\/\/github\.com\/[^ )]+/g
+const filePath = path.join(__dirname, '../README.md');
+const MONTHS_AGO = 18
+const github = initGithubApi(program.token);
 
-var linesWithRepos = _.chain(lines)
-  // store index along with lines
-  .map(function(line, index, collection){
-    return {
-      content: line,
-      index: index
+getLinesFromFile(filePath)
+  .map(addIndexToLines)
+  .filter(filterLinesForGithubUrls)
+  .map(analyzeMatchesAndQueryApi);
+
+function analyzeMatchesAndQueryApi(line){
+  line.matches = line.matches
+    .map(addGithubInfo)
+    .filter(filterGithubInfoExists)
+    .map(queryGithubApiForLastCommit(line));
+  return line;
+}
+
+function queryGithubApiForLastCommit(line){
+  return function(match){
+    var request = {
+      owner: match.info.user,
+      repo: match.info.repo,
+      per_page: 1,
+      page: 1
     };
-  })
-  // only keep lines with github URLs
-  .filter(function(line, index, collection) {
-      var matches = line.content.match(githubUrlRegex);
-      if (matches && matches.length) {
-        line.matches = matches;
-        return true;
-      }
-      return false;
-  })
-  // parse github URLs to objects and send API request
-  .map(function(line){
-    line.matches = _.chain(line.matches)
-      .map(function (match) {
-        return { match: match, info: gh(match) };
-      })
-      .filter(function(match){
-        return match.info != null;
-      })
-      .map(function(match){
-        var request = {
-          owner: match.info.user,
-          repo: match.info.repo,
-          per_page: 1,page: 1
-        };
-        var range = new Date(new Date().setFullYear(new Date().getFullYear() - 2))
-        github.repos.getCommits(request)
-          .then(outdatedHandler(match.info, line.index, line.content, range))
-          .catch(console.error);
-        return match;
-      }).value();
-    return line;
-  })
-  .value();
+    github.repos.getCommits(request)
+      .then(outdatedHandler(match.info, line.index, line.content, thresholdDate))
+      .catch(handleApiError);
+    return match;
+  }
+}
 
-function outdatedHandler(githubInfo, lineIndex, line, compareDate) {
+function handleApiError(error) {
+  console.error('\n' + error);
+  process.exit(1);
+}
+
+function addGithubInfo(match) {
+  return { match: match, info: gh(match) };
+}
+
+function filterLinesForGithubUrls(line, index, collection) {
+    var matches = line.content.match(githubUrlRegex);
+    if (matches && matches.length) {
+      line.matches = matches;
+      return true;
+    }
+    return false;
+}
+
+function getLinesFromFile (filePath) {
+  return fs.readFileSync(
+    filePath,
+    {encoding: 'utf-8'}
+  ).toString().split('\n');
+}
+
+function outdatedHandler(githubInfo, lineIndex, line, thresholdDate) {
   return function (response) {
-    var lastCommitDate = new Date(response[0].commit.author.date);
-    if(lastCommitDate < compareDate){
-      console.log("The last commit of " + githubInfo.https_url + " was: " + lastCommitDate);
-      console.log("line " + (lineIndex + 1) + ": " + line );
-      console.log('\n');
+    const lastCommitDate = new Date(response[0].commit.author.date);
+    if(lastCommitDate < thresholdDate){
+      printOutdatedFind(githubInfo, lastCommitDate, lineIndex, line)
     }
   };
 }
 
-
 function initGithubApi(token) {
-  var github = new GitHubApi({
+  const github = new GitHubApi({
       debug: false,
       protocol: "https",
       host: "api.github.com",
@@ -90,4 +119,21 @@ function initGithubApi(token) {
   }
 
   return github;
+}
+
+function filterGithubInfoExists (match){
+  return match.info != null;
+}
+
+function printOutdatedFind(githubInfo, lastCommitDate, lineIndex, line) {
+  console.log("The last commit of " + githubInfo.https_url + " was: " + lastCommitDate);
+  console.log("line " + (lineIndex + 1) + ": " + line );
+  console.log('\n');
+}
+
+function addIndexToLines(line, index, collection){
+  return {
+    content: line,
+    index: index
+  };
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "scripts": {
+    "list-outdated": "./bin/list_outdated.js"
+  },
+  "dependencies": {
+    "github": "^8.1.1",
+    "github-url-to-object": "2.2.6",
+    "lodash": "4.17.4"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,10 +1,16 @@
 {
+  "name": "awesome-vue",
   "scripts": {
     "list-outdated": "./bin/list_outdated.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vuejs/awesome-vue.git"
+  },
   "dependencies": {
+    "commander": "^2.9.0",
     "github": "^8.1.1",
-    "github-url-to-object": "2.2.6",
-    "lodash": "4.17.4"
-  }
+    "github-url-to-object": "2.2.6"
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
I had some fun building a command line utility that can be used as an indicator to find repositories in README.md that are not maintained anymore.

The tool queries the Github API for the last commit date of the referenced repositories and prints the date, line and line number of the ones older than some threshold amount of months.

You need a Github token from https://github.com/settings/tokens and then call it like so:

```bash
./bin/list_outdated.js --threshold 18 --token your_personal_github_token
```

The output looks like the following:

[outdated.txt](https://github.com/vuejs/awesome-vue/files/740239/outdated.txt)

I'm not completely sure if this is something you guys would like to integrate into the repository, but thought it might be useful. Let me know what you think.