### PR TITLE
Add movingtohttps.com to example sites list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -938,6 +938,7 @@ vue-router 2.0, vue-infinite-scroll 2.0, vue-progressbar 2.0 by [TIGERB](https:/
   - [Shorten Urls with bitly API](https://alpixel.github.io/bitly-vuejs) - Shorten URLs with VueJS &amp; Bitly API
   - [Storyblok](https://www.storyblok.com) - API Based/Decoupled CMS using VueJS for it's frontend.
   - [WizzAir](https://wizzair.com/)
+  - [Moving to HTTPS](https://movingtohttps.com/) - Guide to moving different platform/hosting sites to HTTPS, also [open source](https://github.com/MovingToHTTPS/movingtohttps.com).
 
 - #### Interactive Experiences
 


### PR DESCRIPTION
Hey! Wondered if we could add movingtohttps.com as a simple example showing template usage, plus it's open source :)