### PR TITLE
Add vue-i18n plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -909,6 +909,7 @@ Tooltips / popovers
  - [vue-translate-plugin](https://github.com/javisperez/vuetranslate) - VueJS plugin for translations.
  - [vuex-i18n](https://github.com/dkfbasel/vuex-i18n) - Localization plugin for vue.js 2.0 using vuex as store.
  - [vue-gettext](https://github.com/Polyconseil/vue-gettext) - Translate your Vue.js applications with gettext.
+ - [vue-i18n](https://github.com/MattyRad/vue-i18n) - A small plugin for implementing translations in Vue.js.
 
 ### Custom Events
 


### PR DESCRIPTION
Was removed before during a cleanup, I assume it's because there wasn't a demo or vue 1/2 compatibility description. Added those to the readme https://github.com/MattyRad/vue-i18n