### PR TITLE
add vue-at back with live-demo ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -689,6 +689,7 @@ Tooltips / popovers
  - [vue2-medium-editor](https://github.com/FranzSkuffka/vue-medium-editor) - A MediumEditor component for Vue 2.
  - [vue-froala](https://github.com/helpbase/vue-froala) - VueJS wrapper for Froala Editor.
  - [vue-froala-wysiwyg](https://github.com/froala/vue-froala-wysiwyg) - Official VueJS plugin for Froala WYSIWIG HTML Editor.
+ - [vue-at](https://github.com/fritx/vue-at) - At.js for Vue.
 
 #### Image Manipulation
 


### PR DESCRIPTION
Repo: https://github.com/fritx/vue-at
Live-demo: https://fritx.github.io/vue-at/

Vue-at was removed by a previous review due to a missing live-demo.