### PR TITLE
Updated vue-js-modal & vue-hs-toggle-button and re-added to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,6 +511,7 @@ Tooltips / popovers
 
 - [vuedals](https://github.com/javisperez/vuedals) - A VueJS (2.x) Plugin for multiple modals windows with a single component instance.
 - [sweet-modal-vue](https://github.com/adeptoas/sweet-modal-vue) - The sweetest library to happen to modals. Now available for Vue.js.
+- [vue-js-modal](https://github.com/euvl/vue-js-modal) - Simple to use, highly customizable, mobile friendly Vue.js 2.0+ modal with 0 dependencies.
 
 ### Parallax
 

--- a/README.md
+++ b/README.md
@@ -679,6 +679,7 @@ Tooltips / popovers
 *Switch / on/off toggle / checkbox*
 
  - [vue-switches](https://github.com/drewjbartlett/vue-switches) - An on/off switch component for Vue.js with theme support.
+ - [vue-js-toggle-button](https://github.com/euvl/vue-js-toggle-button) - Vue.js 2.0+ toggle / switch button - simple, pretty, customizable.
 
 #### Masked Input
 


### PR DESCRIPTION
Apparently I've missed all the fuss about revamping awesome-vue :) I've updated readme stating that plugins are designed for vue 2.0+