### PR TITLE
add vue-lazy-images 

### DIFF
--- a/README.md
+++ b/README.md
@@ -887,6 +887,7 @@ Tooltips / popovers
  - [vue-progressive-image](https://github.com/MatteoGabriele/vue-progressive-image) - Vue progressive image loading plugin.
  - [vue-l-lazyload](https://github.com/lsycxyj/vue-l-lazyload) - A lazyload plugin for Vue.js v2.x+.
  - [vue-lazyload-img](https://github.com/JALBAA/vue-lazyload-img) - Especially optimized for mobile browser. support V2 & v1.
+ - [vue-lazy-images](https://github.com/yyh1102/vue-lazyload-images) - A plugin of lazyload images for Vue 2.x.
 
 ### Pagination
 


### PR DESCRIPTION
A plugin of lazyload images for Vue 2.x. The difference among others is that my plugin support images lazyload in window or build-in element with "scroll" feature.