### PR TITLE
add vue-18next

### DIFF
--- a/README.md
+++ b/README.md
@@ -973,6 +973,7 @@ Tooltips / popovers
  - [vue-i18n](https://github.com/MattyRad/vue-i18n) - A small plugin for implementing translations in Vue.js.
  - [vue-multilanguage](https://github.com/leonardovilarinho/vue-multilanguage) - Support many languages in Vue.js 2.
  - [vue-ts-locale](https://github.com/twcapps/vue-ts-locale) - A plugin for implementing translations using Intl in Vue.js 2 with typescript support.
+ - [vue-i18next](https://github.com/panter/vue-i18next) - A i18next wrapper to support translations in Vue.js 2.
 
 ### Custom Events
 


### PR DESCRIPTION
`vue-18next` is a Vue.js wrapperplugin for the [i18next](https://github.com/i18next/i18next) translation library.

It reacts on language change and store updates.