### PR TITLE
Add vue-outside-events

### DIFF
--- a/README.md
+++ b/README.md
@@ -843,6 +843,7 @@ Tooltips / popovers
  - [vue-scrollfire](https://github.com/vue-comps/vue-scrollfire) - Fires an event on a specific scroll position.
  - [vue-resize-directive](https://github.com/David-Desmaisons/Vue.resize) - Vue directive to detect resize events with deboucing and throttling capacity.
  - [v-click-outside](https://github.com/ndelvalle/v-click-outside) - Vue directive to react on clicks outside of an element without stopping the event propagation.
+ - [vue-outside-events](https://github.com/nchutchind/vue-outside-events) - Vue 2.x directive to help a specified element listen for specific events occurring outside of itself.
 
 ### Responsive Design
 


### PR DESCRIPTION
Vue 2.x directive to help a specified element listen for specific events occurring outside of itself. Not just clicks, but any DOM or CustomEvent.