### PR TITLE
Add Vue-Django to list of Open Source projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1257,7 +1257,7 @@ Tooltips / popovers
 
 ## Runtime
 
-### Commnand Line / Terminal
+### Command Line / Terminal
  - [blessed-vue](https://github.com/lyonlai/blessed-vue) - A VueJS runtime to let you write command line UI in Vue Edit
 
 

--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ vue-router 2.0, vue-infinite-scroll 2.0, vue-progressbar 2.0 by [TIGERB](https:/
   - [Guess Right](https://kdcinfo.com/guessright/) - A 'guess the word' game - Written with Vue/vuex/vue-router (front-end) and Laravel/MySQL (back-end). Code is [Open Source on GitHub](https://github.com/KDCinfo/snippets/tree/master/guessright) (although not the live files that run the game at kdcinfo).
   - [GRAP](https://grap.io) - Business communication service
   - [Easy Mock](https://easy-mock.com)
-  - [JSON Schema Editor](https://json-schema-editor.tangramjs.com) - An intuitive editor for JSON schema built with Vue.js and Firebase.  
+  - [JSON Schema Editor](https://json-schema-editor.tangramjs.com) - An intuitive editor for JSON schema built with Vue.js and Firebase.
   - [Winsome Trivia](https://splode.github.io/trivia/) - A single or multiplayer trivia game featuring over 2,000 unique questions built with Vue.js and powered by the Open Trivia Database.
 
 ### Interactive Experiences
@@ -1212,6 +1212,7 @@ Tooltips / popovers
 *Scaffold / boilerplate / seed / starter kits / stack ensemble / Yeoman generator*
 
  - [vue-cli](https://github.com/vuejs/vue-cli) - Simple CLI for scaffolding Vue.js projects.
+ - [Vue-Django](https://github.com/NdagiStanley/vue-django) - A boilerplate to set you up in bringing the awesomeness of VueJS into a Django (Python) app.
 
 ### Client
 

--- a/awesome_vue_with_repo_info.md
+++ b/awesome_vue_with_repo_info.md
@@ -1512,7 +1512,7 @@
    </li>
    <li>
     <strong>
-     <a href="https://github.com/sejr/vuefire-quickstart/">vuefire-quickstart</a> 
+     <a href="https://github.com/sejr/vuefire-quickstart/">vuefire-quickstart</a>
      <!-- Place this tag where you want the button to render. -->
      <a class="github-button"
         href="https://github.com/sejr/vuefire-quickstart"
@@ -1629,6 +1629,12 @@
     <sup>
      &#9733 9, pushed 37 days ago
     </sup>
+   </li>
+   <li>
+    <a href="https://github.com/NdagiStanley/vue-django">
+     Vue-Django
+    </a>
+    - A boilerplate to set you up in bringing the awesomeness of VueJS into a Django (Python) app.
    </li>
   </ul>
  </li>


### PR DESCRIPTION
[Vue-Django](https://github.com/NdagiStanley/vue-django) is built on top of `vue-cli`. With it you have a Django application utilizing the awesomeness of Vue JS out of the box and sets you up on the path of building using VueJS with Django as your backend.

I customized it with the aim of bringing in the awesomeness of VueJS into a Django project and making this process easy.
It has 90+ generic stars showing it usefulness to a number of people. Give it a try.