### PR TITLE
adding vue-mapbox-gl to map section

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,7 +596,7 @@ Tooltips / popovers
 
  - [vue2-google-maps](https://github.com/xkjyeah/vue-google-maps) - Google maps component for vue with 2-way data binding.
  - [vue2-leaflet](https://github.com/KoRiGaN/Vue2Leaflet) - Vue 2 components for Leaflet maps.
-
+ - [vue-mapbox-gl](https://github.com/phegman/vue-mapbox-gl) - Vue 2.x component for Mapbox GL JS
 ### Audio / Video
 
  - [vue-aplayer](https://github.com/SevenOutman/vue-aplayer) - A Vue 2.x component of easy-to-config music players with controls.


### PR DESCRIPTION
A Vue 2.x component for Mapbox GL JS