### PR TITLE
Add Monito to the "Enterprise Usage" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,6 +499,7 @@ vue-router 2.0, vue-infinite-scroll 2.0, vue-progressbar 2.0 by [TIGERB](https:/
  - [ZenMate](https://zenmate.com)
  - [Codeship](https://blog.codeship.com/consider-vuejs-next-web-project/)
  - [Storyblok](https://app.storyblok.com)
+ - [Monito](https://www.monito.com) - Building the Booking.com for international money transfers
 
 
 


### PR DESCRIPTION
Vue is used on most important pages of Monito.
- widgets on the homepage
- main display component + routing on results pages
- main display component on best exchange rates pages
- widgets on money transfer provider profile pages
- etc...

Detection with vue-devtools is not activated on Prod.
Below is a screenshot showing usage of Vue.
<img width="512" alt="screen shot 2017-06-15 at 16 06 57" src="https://user-images.githubusercontent.com/6098129/27185847-d75a9c4c-51e6-11e7-9f3e-9d10c4306652.png">

