### PR TITLE
Add Vue 2 Material Dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,7 @@ vue-router 2.0, vue-infinite-scroll 2.0, vue-progressbar 2.0 by [TIGERB](https:/
 - [Hare](https://github.com/clarkdo/hare) - 🐇 Application boilerplate based on Vue.js 2.x, Koa 2.x, Element-UI and Nuxt.js
 - [Paper-Dashboard](https://github.com/cristijora/vue-paper-dashboard) -Creative Tim Paper Dashboard made for Vue
 - [AdminLTE-VueJS2](https://github.com/otezz/AdminLTE-VueJS2) - An open source project that implements  VueJS (v2.x) on AdminLTE.
+- [Material Dashboard](https://github.com/lucduong/vue-material-dashboard) - Creative Tim Material Dashboard made for Vue
 
 ### Commercial Products
 


### PR DESCRIPTION
The Vue version of Material Dashboard which designed by Creative Tim.
[LIVE DEMO](http://vue-material-dashboard.ltv.vn)

<img width="1280" alt="vue-material-dashboard-1" src="https://user-images.githubusercontent.com/2667418/28169749-7e019276-680d-11e7-97fd-1187ad1e8fc5.png">
