### PR TITLE
Add vue-material-design-icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,6 +638,7 @@ Tooltips / popovers
 ### Icons
 
  - [vue-awesome](https://github.com/Justineo/vue-awesome) - Font Awesome component for Vue.js, using inline SVG.
+ - [vue-material-design-icons](https://gitlab.com/robcresswell/vue-material-design-icons "vue-material-design-icons on GitLab") - A collection of SVG Material Design icons as single file components.
 
 ### Menu
 


### PR DESCRIPTION
Adds the vue-material-design-icons library to the Icons section. This is a collection of inline svg Material Design Icons packaged as single file components.

See https://gitlab.com/robcresswell/vue-material-design-icons or https://www.npmjs.com/package/vue-material-design-icons for more information.