### PR TITLE
Add vue-tooltipster component

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,7 +615,7 @@ Tooltips / popovers
  - [vue-popper-component](https://github.com/antongorodezkiy/vue-popper-component) - Popper.js directive for Vue.js.
  - [vue-directive-tooltip](https://github.com/hekigan/vue-directive-tooltip) - Simple, flexible tooltip directive (based on Popper.js) [![Vue.js](https://img.shields.io/badge/vue-2-green.svg)](https://vuejs.org)
  - [vue-popperjs](https://github.com/RobinCK/vue-popper) - VueJS 2.x popover component based [popper.js](https://popper.js.org/)
-
+ - [vue-tooltipster](https://github.com/cpfarher/vue-tooltipster) - VueJS 2.x tooltip component based [tooltipster.js](http://iamceege.github.io/tooltipster/). Support html content, hover and hover+click events.
 ### Overlay
 
 *Overlay / modal / alert / dialog / lightbox / popup*

--- a/README.md
+++ b/README.md
@@ -616,6 +616,7 @@ Tooltips / popovers
  - [vue-directive-tooltip](https://github.com/hekigan/vue-directive-tooltip) - Simple, flexible tooltip directive (based on Popper.js) [![Vue.js](https://img.shields.io/badge/vue-2-green.svg)](https://vuejs.org)
  - [vue-popperjs](https://github.com/RobinCK/vue-popper) - VueJS 2.x popover component based [popper.js](https://popper.js.org/)
  - [vue-tooltipster](https://github.com/cpfarher/vue-tooltipster) - VueJS 2.x tooltip component based [tooltipster.js](http://iamceege.github.io/tooltipster/). Support html content, hover and hover+click events.
+
 ### Overlay
 
 *Overlay / modal / alert / dialog / lightbox / popup*


### PR DESCRIPTION
I add  a new component for tooltip. It support html content as simple text content.
Also it can be trigger on hover or keep opened with a click.