### PR TITLE
Add vue-swipe-tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -775,6 +775,7 @@ Tooltips / popovers
 ### Tabs
 
  - [vue-tabs](https://github.com/cristijora/vue-tabs) - Simple tabs and pills.
+ - [vue-swipe-tabs](https://github.com/zhangxiang958/vue-tab) - A touch swipe tab component for vue.js(vue2).
 
 ### Form
 


### PR DESCRIPTION
I added vue-swipe-tabs.
## vue-tab - swipe tab simplify

This component is already used in production env.
Overview

vue-tab is a touch swipe tab for vue.js.

## Install

npm install --save vue-swipe-tab
Import using module

import { Tabs, Tab }  from 'vue-swipe-tab';

## demo 
https://zhangxiang958.github.io/vue-tab/demo/index.html