### PR TITLE
Add vue-2-boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1521,6 +1521,7 @@ Tooltips / popovers
  - [MMF-FE/vue-typescript](https://github.com/MMF-FE/vue-typescript) - A vue2.x typescript template.
  - [Friendly Vue Starter](https://github.com/mcongy/friendly-vue-starter) - A full featured Vue.js starter project with GraphQL support via Apollo-client (Vuex, Vue-router, Vue-i18n, Webpack 3, Eslint, Prettier, ...)
  - [vue-webpack-typescript](https://github.com/ducksoupdev/vue-webpack-typescript) - A Vue 2.2 Webpack 2 and Typescript 2 setup with hot reload, unit testing, code coverage, sass and bundling/minification.
+ - [**vue-2-boilerplate**](https://github.com/petervmeijgaard/vue-2-boilerplate) - Vue 2 boilerplate for developing medium to large single page applications by [petervmeijgaard](https://github.com/petervmeijgaard/)
 
 ### Universal
 


### PR DESCRIPTION
This PR adds the [vue-2-boilerplate](https://github.com/petervmeijgaard/vue-2-boilerplate) to the README.md
It's a boilerplate for building medium to large Vue 2 single page applications.
