### PR TITLE
Add vue-blockui into loader section

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,6 +659,7 @@ vue-router 2.0, vue-infinite-scroll 2.0, vue-progressbar 2.0 by [TIGERB](https:/
  - [vuex-loading](https://github.com/f/vuex-loading) - Multiple Loader Management for Vue/Vuex applications.
  - [vue-spinner-component](https://sergeyloysha.github.io/vue-spinner-component/) - Customizable, lightweight spinner for Vue.js.
  - [vue-progress-path](https://github.com/Akryum/vue-progress-path) - Customizable progress indicators and spinners that support any custom SVG path.
+ - [vue-blockui](https://github.com/realdah/vue-blockui) - BlockUI for vue 2, similiar to jquery blockUI, can be used for loading screen.
 
 #### Progress Bar
 


### PR DESCRIPTION
I have created a VUE BlockUI component works as jQuery BlockUI.
Easy to use and support either loading message or/and with animated images from user's choices.
It is built with single vue component which has stylings in-built.

Please can you review and let me know if you can approve my pull request to add this component as part of this list.