### PR TITLE
Add v-dragged to Event Handling list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1166,6 +1166,7 @@ Tooltips / popovers
  - [v-hotkey](https://github.com/Dafrok/v-hotkey) - Vue 2.x directive for binding hotkeys to components.
  - [vue-resize](https://github.com/Akryum/vue-resize) - Vue 2.x component to detect DOM elements resizing (event based/no window.onresize)
  - [vue-observe-visibility](https://github.com/Akryum/vue-observe-visibility) - Vue 2.x directive using Intersection Observer API that detects if the element is visible (in the viewport and not hidden by CSS).
+ - [v-dragged](https://github.com/zhanziyang/v-dragged) - Vue 2.x directive plugin for drag event detection. 
 
 ### Responsive Design
 


### PR DESCRIPTION
[v-dragged](https://github.com/zhanziyang/v-dragged) - Vue 2.x directive plugin for drag event detection. 

This directive listens to the mouse/touch behavior and set a handler for when a drag action is detected. This is different from setting `draggable` attribute on element because you need to move the element yourself according to the information v-dragged provides.

[demo preview](https://zhanziyang.github.io/v-dragged/)