### PR TITLE
Add Vectr to Apps/Websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,6 +582,7 @@ vue-router 2.0, vue-infinite-scroll 2.0, vue-progressbar 2.0 by [TIGERB](https:/
   - [Boardbang](https://boardbang.com) - Media sharing platform.
   - [WynnStats](https://maple3142.github.io/wynn/) - A unofficial WynnCraft statistics.
   - [Save Coins](https://savecoins.me) - Save Coins helps Nintendo Switch owners to save money on Nintendo eShop.
+  - [Vectr](https://vectr.com/new) - A free vector graphics software
 
 ### Interactive Experiences
 


### PR DESCRIPTION
Vue is not detected by Vue-Devtools, but source shows it uses Vue

![screen shot 2017-10-16 at 4 55 41 pm](https://user-images.githubusercontent.com/7766185/31603729-a2cf0f68-b293-11e7-9635-6319e386db24.png)
