### PR TITLE
Add drum synth site using Vue and the Web Audio API

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,6 +594,7 @@ vue-router 2.0, vue-infinite-scroll 2.0, vue-progressbar 2.0 by [TIGERB](https:/
  - [Tolks.io](https://tolks.io)
  - [Meet Graham](http://www.meetgraham.com.au)
  - [NOIZE original](http://noizeoriginal.com)
+ - [TR-101 Synth Drum Machine](https://inverted3.gitlab.io/drum-machine)
 
 ### Enterprise Usage
 


### PR DESCRIPTION
Vue-Devtools does not detect because the flag is set to false.

See [repo](https://gitlab.com/inverted3/drum-machine) for validation that it uses Vue