### PR TITLE
Add Vue Elucidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1553,6 +1553,7 @@ Payment utilities.
  - [propdoc](https://github.com/propellant/doctor) - A single component that provides simple documentation of Vue.js components/props.
  - [Vuex CheatSheet](https://vuejs-tips.github.io/vuex-cheatsheet) - Complete Interactive Vuex API.
  - [vue-styleguidist](https://github.com/vue-styleguidist/vue-styleguidist) - A style guide generator for Vue components with a living style guide.
+ - [vue-elucidate](https://github.com/mattrothenberg/vue-elucidate) - A component that generates beautiful documentation for your living styleguide / design system.
 ### Test
 
  - [avoriaz](https://github.com/eddyerburgh/avoriaz) - A Vue.js testing utility library.


### PR DESCRIPTION
Elucidate is a library that makes it a breeze to "shed light" on your Vue component by automatically generating documentation.

