### PR TITLE
Add vue-static-map

### DIFF
--- a/README.md
+++ b/README.md
@@ -820,6 +820,7 @@ Tooltips / popovers
  - [vue-choropleth](https://github.com/voluntadpear/vue-choropleth) - Vue 2.x component to display a choropleth map.
  - [vuelayers](https://github.com/ghettovoice/vuelayers) - Vue 2 components to work with OpenLayers.
  - [vue-googlemaps](https://github.com/Akryum/vue-googlemaps) - Vue 2.x components to integrate Google Maps.
+ - [vue-static-map](https://github.com/eperedo/vue-static-map) - Vue 2.x simple component to generate an static google map
 
 ### Audio / Video
 


### PR DESCRIPTION
vue-static-map is a simple component for generate a [static google map](https://github.com/eperedo/vue-static-map)