### PR TITLE
added "vue-ico" to #icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -755,6 +755,7 @@ Tooltips / popovers
  - [vue-material-design-icons](https://gitlab.com/robcresswell/vue-material-design-icons "vue-material-design-icons on GitLab") - A collection of SVG Material Design icons as single file components.
  - [vue-icon-font](https://github.com/ganl/vue-icon-font) - A iconfont plugin for Vuejs (support Font-class and Symbol).
  - [vue-ionicons](https://github.com/mazipan/vue-ionicons) - Vue Icon Set Components from Ionic Team.
+ - [vue-ico](https://github.com/paulcollett/vue-ico) - Dead easy icons for Vue with drop-in browser support & selective bundling
 
 ### Menu
 


### PR DESCRIPTION
Added "vue-ico" under the Icons heading.

"vue-ico" takes a very simplistic setup approach to bringing icons to vue