### PR TITLE
add vue-flexible-link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1720,6 +1720,7 @@ Payment utilities.
 
  - [Electron Vue](https://github.com/SimulatedGREG/electron-vue) - An Electron & Vue.js quick start boilerplate with vue-cli scaffolding, common Vue plugins, electron-packager/electron-builder, unit/e2e testing, vue-devtools, and webpack.
  - [VuePack](https://github.com/egoist/vuepack) - A modern starter which uses Vue 2, Vuex, Vue-router and Webpack 2 (and even Electron).
+ - [vue-flexible-link](https://github.com/saintplay/vue-flexible-link) - Tiny Vue component for Electron to open links in a browser. Ideal for cross environment apps (Web & Native)
 
 ### Parts
 


### PR DESCRIPTION
Tiny Vue component for Electron to open links in a browser. Ideal for cross environment apps (Web & Native)

**No demo** provided because this component is intended to be used with Electron