### PR TITLE
Add vue-amap into 'Maps section'

### DIFF
--- a/README.md
+++ b/README.md
@@ -852,6 +852,7 @@ Tooltips / popovers
  - [vuelayers](https://github.com/ghettovoice/vuelayers) - Vue 2 components to work with OpenLayers.
  - [vue-googlemaps](https://github.com/Akryum/vue-googlemaps) - Vue 2.x components to integrate Google Maps.
  - [vue-static-map](https://github.com/eperedo/vue-static-map) - Vue 2.x simple component to generate an static google map
+ - [vue-amap](https://github.com/ElemeFE/vue-amap/) - Vue 2.x component for [AMap](http://www.amap.com).
 
 ### Audio / Video
 


### PR DESCRIPTION
Add vue-amap, based on another maps product called [AMap](http://ditu.amap.com/), which is popular in China besides Baidu Maps.