### PR TITLE
add generator-vue-component-developer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1784,7 +1784,9 @@ Payment utilities.
  - [vuejs-wordpress-theme-starter](https://github.com/EvanAgee/vuejs-wordpress-theme-starter) - A WordPress theme with the guts ripped out and replaced with Vue
  - [Cordovue](https://github.com/TheMushrr00m/cordovue) - A sample Apache Cordova application using Vue.
  - [Cookiecutter-Django-Vue](https://github.com/vchaptsev/cookiecutter-django-vue) - Django+VueJS+Docker customizable project generator with a large number of settings/integrations by ([@vchaptsev](https://github.com/vchaptsev/))
+ - [vue-component-developer](https://github.com/KELEN/generator-vue-component-developer) - A vue component develop boilerplate to enable you quick develop your vue component or directive.
 
+ 
 ### Client
 
 *Render Vue application in the browser only*


### PR DESCRIPTION
A vue component develop boilerplate to enable you quick develop your vue
component or directive.