### PR TITLE
Removing "vue-side-nav"

### DIFF
--- a/README.md
+++ b/README.md
@@ -803,7 +803,6 @@ Tooltips / popovers
 
 ### Menu
 
- - [vue-side-nav](https://github.com/vue-comps/vue-side-nav) - Side-nav.
  - [vue-accordion](https://github.com/zeratulmdq/vue-accordion) - Simple accordion nav menu component for Vue.js.
  - [vue-js-dropdown](https://github.com/euvl/vue-js-dropdown) - Vue.js 2 dropdown menu component. Light, easy to use and extend, no external deps.
  - [vue-slideout](https://github.com/vouill/vue-slideout) - Vue implementation of the popular library [slideout](https://github.com/Mango/slideout)


### PR DESCRIPTION
* their GitHub repo indicates that the component is now depricated