### PR TITLE
update Readme.md / added Bit for managing vue components

### DIFF
--- a/README.md
+++ b/README.md
@@ -1686,8 +1686,9 @@ Payment utilities.
  - [vuepack.org](http://vuepack.org) - A simple page that allows you to select Vue components and download them as a single minified JS file.
  - [Storybook](https://storybook.js.org) - The UI Development Environment. works with v3.2+ later.
  - [Font Awesome Finder](https://chrome.google.com/webstore/detail/font-awesome-icon-finder/kjejboahkcobalmgldloeinebmbomgog) - Chrome extension to search, preview and choose Font Awesome icons and copy the selected icon HTML code & Unicode to clipboard.
- - [vue-dummy](https://github.com/paulcollett/vue-dummy) - Placeholder Text and Dummy Images as a simple `v-dummy` directive
-
+ - [vue-dummy](https://github.com/paulcollett/vue-dummy) - Placeholder Text and Dummy Images as a simple `v-dummy` directive.
+ - [Bit](https://github.com/teambit/bit) - Manage and reuse `vue` components between projects. Easily isolate ans share components from any projec without chagning its source code, organize curated collections and install in different projects. 
+ 
 ### Inspect
 
 *Inspecting & debugging*


### PR DESCRIPTION
Added Bit under Dev Tools for managing Vue components between projects:
isolating, sharing, organizing, discovering and installing in different apps using Yarn / NPM.
Also added "." for `vue-dummy` :)