### PR TITLE
Add @julon/vue-cli-template-*

### DIFF
--- a/README.md
+++ b/README.md
@@ -1863,7 +1863,9 @@ Payment utilities.
  - [**vue-2-boilerplate**](https://github.com/petervmeijgaard/vue-2-boilerplate) - Vue 2 boilerplate for developing medium to large single page applications by [petervmeijgaard](https://github.com/petervmeijgaard/)
  - [layout](https://github.com/ktquez/layout) - A full-featured Webpack + Vue Extend layout
  - [layout-simple](https://github.com/ktquez/layout-simple) - A simple Webpack + Vue Extend layout
-
+ - [vue-cli-template-library](https://github.com/julon/vue-cli-template-library) - Template for developing open-source vue.js libraries with Rollup + Jest + Babel + Storybook + TravisCI + SemanticRelease.
+ - [vue-cli-template-github-pages](https://github.com/julon/vue-cli-template-github-pages) - A full-featured Webpack + vue-loader setup for Github Pages Deployment with travisCI.
+ 
 ### Universal
 
 *Render Vue application to HTML on the server and to the DOM in the browser*


### PR DESCRIPTION
- Add vue-cli-template-library : A vue-cli template for creating vuejs components library easily.
- Add vue-cli-template-github-pages : A fork of official vue-cli webpack template with some github pages adjustments.