### PR TITLE
Remove `grammarly.com` from the "Apps/Websites"

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,7 +557,6 @@ vue-router 2.0, vue-infinite-scroll 2.0, vue-progressbar 2.0 by [TIGERB](https:/
   - [稀土掘金](http://gold.xitu.io)
   - [Prague Airport](http://www.prague-airport.com/)
   - [Portfolio Site](http://corentinbac.com/)
-  - [Grammarly](https://grammarly.com/) - Mistake-free writing service.
   - [Laravist](https://laravist.com/)
   - [Atiiv](https://atiiv.com) - An app aimed for personal trainers and their clients.
   - [Statamic](https://statamic.com)


### PR DESCRIPTION
Can't find Vue on the grammarly pages anymore. It seems like they fully migrated to React.
Check performed with Vue DevTools + Wappalyzer