### PR TITLE
Add zipkin-instrumentation-vue-resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -1579,6 +1579,7 @@ Tooltips / popovers
  - [vue-async-properties](https://github.com/blainehansen/vue-async-properties) - An `asyncData` and `asyncComputed` plugin with support for debouncing, transforming results, error handlers, loading/pending flags, lazy/eager requests.
  - [vue-axios-plugin](https://github.com/yugasun/vue-axios-plugin) - A plugin that combines axios with Vuejs, making http request more easier.
  - [vuex-api](https://github.com/vouill/vuex-api) - A vuex plugin for effortlessly handle api calls.
+ - [zipkin-instrumentation-vue-resource](https://github.com/elgris/zipkin-instrumentation-vue-resource) - An interceptor for [vue-resource](https://github.com/pagekit/vue-resource) that instruments outgoing HTTP requests with [Zipkin](https://github.com/openzipkin/zipkin)
 
 ### i18n
 


### PR DESCRIPTION
An interceptor for [vue-resource](https://github.com/pagekit/vue-resource) that adds some [Zipkin](https://github.com/openzipkin/zipkin) love to Vue applications.

Sometimes tracing of backend components is not enough, so you need to do some tracing on frontend side (part of End User Monitoring). `zipkin-instrumentation-vue-resource` helps with that.