### PR TITLE
Add "Youtube Channels" section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
     - [Community](#community)
     - [Conferences](#conferences)
     - [Podcasts](#podcasts)
+    - [Youtube Channels](#youtube-channels)
     - [Official Examples](#official-examples)
     - [Tutorials](#tutorials)
     - [Examples](#examples)
@@ -212,6 +213,10 @@
 - [The Web Platform Podcast 132: Vue.js (07-27-2017)](http://thewebplatformpodcast.com/132-vuejs)
 - [JavaScript Jabber #276 with Maximilian Schwarzmüller (08-29-2017)](https://devchat.tv/js-jabber/jsj-276-vue-js-maximilian-schwarzmuller)
 - [Animating VueJS with Sarah Drasner(Software Engineering Daily 01-12-2017)](https://softwareengineeringdaily.com/2017/12/01/animating-vuejs-with-sarah-drasner/)
+
+### Youtube Channels
+ - [VueNYC](https://www.youtube.com/vuenyc)
+ - [VueConf EU](https://www.youtube.com/channel/UC9dJjbYeXjirDYYVfUD3bSw)
 
 ### Official Examples
 


### PR DESCRIPTION
There is a growing number of Youtube channels, mostly from meetups and conferences which regularly produce *awesome* vuejs content, such as VueNYC and VueConf EU (and soon Vue Amsterdam)

So I added a new category, so that those interested can follow the channels :)