### PR TITLE
Add VueConf US to conferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,8 +197,8 @@
 ### Conferences
 
 - [VueConf](http://conf.vuejs.org)
-- [VueConf US](http://vueconf.us)
 - [Vue.js London](http://vuejs.london)
+- [VueConf US](http://vueconf.us)
 
 ### Podcasts
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@
 ### Conferences
 
 - [VueConf](http://conf.vuejs.org)
+- [VueConf US](http://vueconf.us)
 - [Vue.js London](http://vuejs.london)
 
 ### Podcasts


### PR DESCRIPTION
The first US conference for Vue.js was announced.
-> Added link to VueConf US page