### PR TITLE
update Vuikit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1365,6 +1365,7 @@ Tooltips / popovers
 
 *Set of components + responsive layout system*
 
+ - [Vuikit](https://vuikit.js.org) - A responsive Vue UI library based on the front-end framework UIkit.
  - [quasar-framework](https://github.com/quasarframework/quasar) - Quasar Framework. Build responsive websites, hybrid mobile Apps (that look native on Android and iOS) and Electron apps using same code, with VueJs 2.
  - [vue-material](https://github.com/vuematerial/vue-material) - Material design for Vue.js.
  - [vuetify](https://github.com/vuetifyjs/vuetify) - Material Component Framework for Vue.js 2.
@@ -1401,7 +1402,6 @@ Tooltips / popovers
  - [vue-mdc](https://github.com/posva/vue-mdc) - Material Components Web for Vue.js.
  - [keen-ui](https://github.com/JosephusPaye/Keen-UI) - A lightweight collection of essential UI components written with Vue and inspired by Material Design.
  - [vue-admin](https://github.com/vue-bulma/vue-admin) - Vue Admin Panel Framework, Powered by Vue 2.0 and Bulma 0.3.
- - [vuikit](https://github.com/vuikit/vuikit) - UIkit with all the power of Vue.
  - [uiv](https://github.com/wxsms/uiv) Bootstrap3 components implemented by Vue2.
  - [yuche/vue-strap](https://github.com/yuche/vue-strap) - Bootstrap 3 components built with Vue.js 1
  - [wffranco/vue-strap](https://github.com/wffranco/vue-strap) - Bootstrap 3 components built with Vue.js 2


### PR DESCRIPTION
I am opening this PR in efforts to update the Vuikit listing description and place it in the right list, among frameworks, as Vuikit relies on UIkit which provides a _responsive layout system_.

While doing that though, I found the list ordering odd. Quasar Framework which has been added on a later date than Vuetify or vue-material, is now the first on the list. Is it perhaps ordered by popularity? I doubt it, so I placed Vuikit first as if you check the History it is where it belongs.

But I didn't checked the entire list, and there could be other listing with older history. The Vuetify it self should go before Quasar, etc... If I got a clarification about the order, I could reorder the list accordingly in a new PR.