### PR TITLE
Add hubble.js.org to projects using Vue.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,7 @@ vue-router 2.0, vue-infinite-scroll 2.0, vue-progressbar 2.0 by [TIGERB](https:/
 
 ### Open Source
 
+ - [Hubble](https://hubble.js.org) - :telescope: Travel through GitHub Stars' history.
  - [PageKit](https://github.com/pagekit/pagekit) - Modular and lightweight CMS built with Symfony components and Vue.js.
  - [npmcharts.com](https://github.com/cheapsteak/npmcharts.com) - Compare npm packages and spot download trends.
  - [Koel](https://github.com/phanan/koel) - A personal music streaming server that works.

--- a/README.md
+++ b/README.md
@@ -487,7 +487,6 @@ vue-router 2.0, vue-infinite-scroll 2.0, vue-progressbar 2.0 by [TIGERB](https:/
 
 ### Open Source
 
- - [Hubble](https://hubble.js.org) - :telescope: Travel through GitHub Stars' history.
  - [PageKit](https://github.com/pagekit/pagekit) - Modular and lightweight CMS built with Symfony components and Vue.js.
  - [npmcharts.com](https://github.com/cheapsteak/npmcharts.com) - Compare npm packages and spot download trends.
  - [Koel](https://github.com/phanan/koel) - A personal music streaming server that works.
@@ -593,6 +592,7 @@ vue-router 2.0, vue-infinite-scroll 2.0, vue-progressbar 2.0 by [TIGERB](https:/
 - [Deezer-Vue](https://sh0cked.github.io/deezer-vue/) - Deezer client built with Vue\Vuex
 - [Vuep.run](https://vuep.run) - Online SFC editor for Vue
 - [V·oogle](https://github.com/VeryWow/v-oogle) - Google.com, reVued
+- [Hubble](https://hubble.js.org) - :telescope: Travel through GitHub Stars' history.
 
 
 ### Commercial Products


### PR DESCRIPTION
Add Hubble(https://hubble.js.org) to Open Source projects using Vue.js