### PR TITLE
Add vue-tiny-lazyload-img

### DIFF
--- a/README.md
+++ b/README.md
@@ -1570,6 +1570,7 @@ Tooltips / popovers
  - [vue-lazy-this](https://github.com/thangman22/vue-lazy-this) - Lazyloading component using Intersection Observer API.
  - [v2-lazy-list](https://github.com/dwqs/v2-lazy-list/) - A simple lazy-load list component based Vue 2.x
  - [pimg](https://github.com/ooade/pimg) - A Simple Progressive Image Component used for lazy loading images.
+ - [vue-tiny-lazyload-img](https://github.com/mazipan/vue-tiny-lazyload-img) - A small size Vue.js v.2+ directive for lazy loading images
 
 ### Pagination
 


### PR DESCRIPTION
Add **vue-tiny-lazyload-img** : A small size Vue.js v.2+ directive for lazy loading images

Repo: https://github.com/mazipan/vue-tiny-lazyload-img
Demo: https://mazipan.github.io/vue-tiny-lazyload-img/ 
NPM: https://www.npmjs.com/package/vue-tiny-lazyload-img