### PR TITLE
Add dapp - Boilerplate for Vue/Parcel/Electron

### DIFF
--- a/README.md
+++ b/README.md
@@ -2162,6 +2162,7 @@ Payment utilities.
  - [vue-flexible-link](https://github.com/saintplay/vue-flexible-link) - Tiny Vue component for Electron to open links in a browser. Ideal for cross environment apps (Web & Native)
  - [vuelectron](https://github.com/rachmanzz/vuelectron) - electronjs starter kits for vue.
  - [vue-design](https://github.com/L-Chris/vue-design) - the best website visualization builder with Vue and Electron.
+ - [dapp](https://github.com/fritx/dapp) - Boilerplate for stack of Vue/Parcel/Electron.
 
 ### Parts
 


### PR DESCRIPTION
- [eddyerburgh/parcel-vuejs-template](https://github.com/eddyerburgh/parcel-vuejs-template)
- [fritx/dapp](https://github.com/fritx/dapp)