### PR TITLE
docs(auth): add `casl-vue` to the list of libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1858,6 +1858,7 @@ the amazing Vue.js.
  - [vue-kindergarten](https://github.com/JiriChara/vue-kindergarten)
  - [vue-authenticate](https://github.com/dgrubelic/vue-authenticate) - Simple Vue.js authentication library for login/register and OAuth (1.0/2.0) authentication
  - [vue-facebook-account-kit](https://github.com/biessek/vue-facebook-account-kit) - Simple vue wrapper to the fb account kit library.
+ - [casl-vue](https://github.com/stalniy/casl/tree/master/packages/casl-vue) - Restricts what resources a given user is allowed to access
 
 #### Vuex Utilities
 


### PR DESCRIPTION
`casl-vue` was really useful for me. It allows to show/hide some UI functionality based on what user can do in the application
Don't know why it's not in this list yet :)