### PR TITLE
Add vue-context to the context menu list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1375,6 +1375,7 @@ Tooltips / popovers
  - [vue-lil-context-menu](https://github.com/timwis/vue-lil-context-menu) - A flexible lil context menu component for Vue.
  - [vue-mouse-menu](https://github.com/zgj233/vue-mouse-menu) - A mouse-menu component for vue 2+.
  - [@hscmap/vue-menu](https://github.com/michitaro/vue-menu) - Menu / Context Menu component for vue2.
+ - [vue-context](https://github.com/rawilk/vue-context) - A simple but flexible context menu for vue js.
 
 #### Miscellaneous
 


### PR DESCRIPTION
Please add my context menu component to the context menu list. It allows you to leverage your own menu template and also has default styling in place for a basic `ul` element. The documentation is clear and has a screenshot, as well as a link to a demo on Github Pages.