### PR TITLE
adding chrome-ribbon-reminder

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,6 +614,7 @@
  - [Laqu-l](https://github.com/laqul/laqul) - A complete App starter kit with Quasar Framework, GraphQL API backend with OAUTH 2.0 authentication, Firebase ready, multilanguage capability and more.
  - [Protovue](https://github.com/v1Labs/protovue) - A prototyping component library that helps designers and developers quicky scaffold an abstracted app layout.
 - [Chattier](https://github.com/raniesantos/chattier) - SPA social network built with Laravel 5.6, Vue.js 2, and Bulma (Buefy components + Bulmaswatch themes). Also uses JWT authentication.
+- [chrome-ribbon-reminder](https://github.com/johndatserakis/chrome-ribbon-reminder) - A Chrome extension written using Vue and Async/Await. Uses a popup display and changes badge counts.
 
 ### Commercial Products
 


### PR DESCRIPTION
Added [chrome-ribbon-reminder](https://github.com/johndatserakis/chrome-ribbon-reminder) to Projects Using Vue.js -> Open Source. 