### PR TITLE
v-show-slide added

### DIFF
--- a/README.md
+++ b/README.md
@@ -1202,7 +1202,7 @@ Tooltips / popovers
  - [vue-text-highlight](https://github.com/AlbertLucianto/vue-text-highlight) - Text highlighter library for Vue.js 💄
  - [vue2-hammer](https://github.com/bsdfzzzy/vue2-hammer) Hammer.js wrapper for Vue 2.x to support mobile touch..
  - [vue-countable](https://github.com/johndatserakis/vue-countable) - Vue binding for countable.js. Provides real-time paragraph, sentence, word, and character counting.
-
+ - [v-show-slide](https://github.com/phegman/v-show-slide) - A Vue.js directive for animating an element to and from height: auto in a sliding motion.
 
 ### Tabs
 


### PR DESCRIPTION
`v-show-slide`, A Vue.js directive for animating an element to and from `height: auto` in a sliding motion added to Miscellaneous components section.