### PR TITLE
Adds vue-a11y-dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -952,6 +952,7 @@ Tooltips / popovers
 - [vue-cute-modal](https://github.com/dillonchanis/vue-cute-modal) - A simple and easy to use Modal component for Vue applications.
 - [v-dialogs](https://github.com/TerryZ/v-dialogs) - A simple and powerful dialog, including Modal, Alert, Mask and Toast modes, based on Vue2.x
 - [vue-gallery-slideshow](https://github.com/KitchenStories/vue-gallery-slideshow) - Responsive gallery component for VueJS
+- [vue-a11y-dialog](https://github.com/morkro/vue-a11y-dialog) - A Vue.js component wrapper for the accessible dialog [`a11y-dialog`](https://github.com/edenspiekermann/a11y-dialog).
 
 ### Parallax
 


### PR DESCRIPTION
This adds [`vue-a11y-dialog`](https://github.com/morkro/vue-a11y-dialog), a wrapper component for the popular accessible dialog component [`a11y-dialog`](https://github.com/edenspiekermann/a11y-dialog).