### PR TITLE
Added loopback-vue-starter template

### DIFF
--- a/README.md
+++ b/README.md
@@ -2090,6 +2090,7 @@ Payment utilities.
  - [amazon-cognito-vuex-module](https://github.com/Botre/amazon-cognito-vuex-module) - Vuex module for Amazon Cognito.
  - [vue-web3](https://github.com/morrislaptop/vue-web3) - Web3 blockchain bindings for Vue.js (inspired by Vuefire and Drizzle)
   - [sbt-vuefy](https://github.com/GIVESocialMovement/sbt-vuefy) - Vue.js integration for Playframework
+  - [loopback-vue-starter](https://github.com/ivandov/loopback-vue-starter) - LoopBack and Vue starter template with easy plugin management through `vue-cli` and `vue ui`.
 
 ###### Google Analytics
 


### PR DESCRIPTION
This starter template differs signficantly from the the existing `vue-loopback` template as it does not pre-configure authentication, localStorage, gulp, bootstrap, or any other tightly-coupled integration into the base template. It's meant for easy expansion depending on a specific project's requirements.