### PR TITLE
Removed dead link to the vue-xeditable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1282,10 +1282,6 @@ Tooltips / popovers
 
 *Let the user create & edit data*
 
-#### Editable
-
-- [vue-xeditable](https://github.com/Kar-Wai-Wong/vue-xeditable) - Better editable Component in Vue Edit.
-
 #### Picker
 
  - [vue-smooth-picker](https://github.com/hiyali/vue-smooth-picker) - A smooth picker component for Vue 2.x, like iOS native datetime picker.


### PR DESCRIPTION
vue-xeditable has been deprecated according to https://www.npmjs.com/package/vue-xeditable