### PR TITLE
Updated README with QIT Podcast search result

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@
 - [Animating VueJS with Sarah Drasner(Software Engineering Daily 01-12-2017)](https://softwareengineeringdaily.com/2017/12/01/animating-vuejs-with-sarah-drasner/)
 - [Views on Vue (weekly podcast on Vue started 03-06-2018)](https://devchat.tv/views-on-vue)
 - [The Official Vue.js News Podcast](https://news.vuejs.org/)
+- [Vue podcast list via The QIT Tech Podcast Indexer](https://qit.cloud/search/vue)
 
 ### Youtube Channels
  - [VueNYC](https://www.youtube.com/vuenyc)


### PR DESCRIPTION
[QIT](https://qit.cloud) is a free open source service that indexes software development podcasts so they can be found by topic.  Searches look for matches in podcast titles, episode titles, and show notes. I have added the search result for all podcasts that match Vue.

The source code for QIT can be found here:
* https://github.com/codingblocks/podcast-app