### PR TITLE
Updated RSS Reader name to Raven Reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,7 +520,7 @@
  - [PageKit](https://github.com/pagekit/pagekit) - Modular and lightweight CMS built with Symfony components and Vue.js.
  - [npmcharts.com](https://github.com/cheapsteak/npmcharts.com) - Compare npm packages and spot download trends.
  - [Koel](https://github.com/phanan/koel) - A personal music streaming server that works.
- - [RSS Reader](https://github.com/mrgodhani/rss-reader) - Simple RSS Reader made using atom electron and vue.js.
+ - [Raven Reader](https://github.com/mrgodhani/raven-reader) - Simple RSS Reader made using atom electron and vue.js.
  - [Gokotta](https://github.com/Zhangdroid/Gokotta) - A simple music player built by electron and vue.
  - [CoPilot](https://github.com/misterGF/CoPilot) - An admin portal based on AdminLTE with vue.js integration.
  - [Retrospectify](https://github.com/pepf/retrospectify) - A simple tool for doing collaborative retrospectives in agile teams.


### PR DESCRIPTION
Recently we changed our app name and branding. Now it is called Raven Reader.