### PR TITLE
Add GitHubExplorer to Apps/Websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -820,6 +820,7 @@
   - [Elvenar](https://en.elvenar.com/) - Elvenar is a browser based fantasy city builder game.
   - [Beacon](https://beaconapp.in) - :blue_heart: A service that allows you to share your content across multiple websites.
   - [Artfinder](https://www.artfinder.com/) - Artfinder is a website for buying & selling art paintings.
+  - [GitHubExplorer](https://kiinlam.github.io/GitHubExplorer/) - Pure static page webapp for exploring GitHub. Using `Vuejs` and `GitHub GraphQL API v4`.
 
 ### Interactive Experiences
 


### PR DESCRIPTION
A static page webapp.

GitHub: https://github.com/kiinlam/GitHubExplorer

Website: https://kiinlam.github.io/GitHubExplorer