### PR TITLE
add vue-doughnut-chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1146,6 +1146,7 @@ Tooltips / popovers
  - [vue-jqxchart](https://github.com/jqwidgets/vue/tree/master/chart) - Charting component with Pie, Bubble, Donut, Line, Bar, Column, Area, Waterfall, Polar & Spider series.
  - [toast-ui.vue-chart](https://github.com/nhnent/toast-ui.vue-chart) - Vue Wrapper for [TOAST UI Chart](http://ui.toast.com/tui-chart/).
  - [vue-apexcharts](https://github.com/apexcharts/vue-apexcharts) - Vue.js component for [ApexCharts](https://github.com/apexcharts/apexcharts.js).
+ - [vue-doughnut-chart](https://github.com/mazipan/vue-doughnut-chart) - Doughnut chart component for Vue.js.
 
 
 ### Time


### PR DESCRIPTION
Add `vue-doughnut-chart`

Repo: [https://github.com/mazipan/vue-doughnut-chart](https://github.com/mazipan/vue-doughnut-chart)
Demo: [https://mazipan.github.io/vue-doughnut-chart](https://mazipan.github.io/vue-doughnut-chart)
NPM Package: [https://www.npmjs.com/package/vue-doughnut-chart](https://www.npmjs.com/package/vue-doughnut-chart)