### PR TITLE
Add RosterWebApp as an Open Source project.

### DIFF
--- a/README.md
+++ b/README.md
@@ -704,6 +704,7 @@
 - [Carpoolear](https://github.com/STS-Rosario/carpoolear) The open source Vue.js frontend (mobile and cordova app) for the argentinian carpooling application: [Carpoolear](https://carpoolear.com.ar)
 - [Statusfy](https://github.com/bazzite/statusfy): Statusfy is a Status Page System, easy to use and completely Open Source.
 - [DynamoDb-GUI-Client](https://github.com/Arattian/DynamoDb-GUI-Client): Cross-platform GUI client for DynamoDb
+- [RosterWebApp](https://github.com/SnakeyHips/RosterWebApp) Open source rostering web application which allows the rostering of employees/teams to work sessions and other features.
 
 ### Commercial Products
 


### PR DESCRIPTION
Added RosterWebApp which is an open source rostering web application which allows the rostering of employees/teams to work sessions with appointed and overtime hours. Includes standard CRUD operations, viewing of rostered hours, where an employee/team are between two given dates, assigning absences and other features.

[Link to repo.](https://github.com/SnakeyHips/RosterWebApp/)