### PR TITLE
Added Vue-MathLive

### DIFF
--- a/README.md
+++ b/README.md
@@ -1593,6 +1593,7 @@ Tooltips / popovers
  - [tiptap](https://github.com/heyscrumpy/tiptap) - A renderless and extendable rich-text editor for Vue.js
  - [toast-ui.vue-editor](https://github.com/nhnent/toast-ui.vue-editor) - Vue Wrapper for [TOAST UI Editor](http://ui.toast.com/tui-editor).
  - [ckeditor5-vue](https://github.com/ckeditor/ckeditor5-vue) - An official CKEditor 5 rich text editor component for Vue.js.
+ - [vue-mathlive](https://github.com/arnog/vue-mathlive) A MathLive math editor (mathfield) for Vue.hjs
 
 #### Image Manipulation
 


### PR DESCRIPTION
The MathLive Vue wrapper provides a Vue component that implements a `<mathfield>` HTML tag.
The component can be used to edit formulas using the MathLive library. The editor provides a rich, accessible, editing UI, including virtual keyboards for mobile, and can provide the output as LaTeX, MathML or spoken text.