### PR TITLE
Add vue-katex

### DIFF
--- a/README.md
+++ b/README.md
@@ -1410,6 +1410,7 @@ Tooltips / popovers
  - [vue-resize-text](https://github.com/JayeshLab/vue-resize-text) - A vue directive which automatically resize font size based on element width.
  - [vue-github-profile](https://github.com/GabrielBibiano/vue-github-profile) - A vue component to view the profile and repos of determined user
  - [vue-niege](https://github.com/P3trur0/vue-niege) - 🎄 🎅 Single File Vue component to add a snow storm through a canvas.
+ - [vue-katex](https://github.com/lucpotage/vue-katex) - Simple plugin for math typsetting using KaTeX in Vue.js
 
 ### Tabs
 


### PR DESCRIPTION
vue-katex is a Vue.js plugin that enables [KaTeX](https://github.com/KaTeX/KaTeX) to be used in Vue.js applications