### PR TITLE
Add VueMapbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -1259,6 +1259,7 @@ Tooltips / popovers
  - [vuelayers](https://github.com/ghettovoice/vuelayers) - Vue 2 components to work with OpenLayers.
  - [vue-googlemaps](https://github.com/Akryum/vue-googlemaps) - Vue 2.x components to integrate Google Maps.
  - [vue-static-map](https://github.com/eperedo/vue-static-map) - Vue 2.x simple component to generate an static google map
+ - [vue-mapbox](https://github.com/soal/vue-mapbox) - Vue 2.x wrapper around Mapbox GL JS library that provides vueish-way to interact with the map.
 
 ### Audio / Video
 


### PR DESCRIPTION
[Vue-mapbox](https://github.com/soal/vue-mapbox)  is a wrapper around Mapbox GL JS library that provides a declarative way to interact with the map.