### PR TITLE
Added vue-simple-inline-translation under i18n

### DIFF
--- a/README.md
+++ b/README.md
@@ -2197,6 +2197,7 @@ the amazing Vue.js.
  - [vue-i18n-filter](https://github.com/chiaweilee/vue-i18n-filter) -  Vue filter extend for Vue-i18n, simply using `{{ hello world | t }}`.
  - [vue-translation-manager](https://github.com/cyon/vue-translation-manager) - Interactively find and translate strings in your Vue.js application. Works well with vue-18n and vuex-i18n.
  - [vue-t9n](https://github.com/Ni55aN/vue-t9n) - Simplest way to translate your applications
+ - [vue-simple-inline-translation](https://github.com/alidrus/vue-simple-inline-translation) - A Vue component that simplifies the way text is translated: by translating it inline.
 
 ### Custom Events
 


### PR DESCRIPTION
I've added a small component that I wrote to simplify translation for people who do not like to have a separate array in their js code for mapping translations.