### PR TITLE
Adding vue-simple-bem directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -2381,6 +2381,7 @@ the amazing Vue.js.
  - [vue-mods-names](https://github.com/RGRU/vue-mods-names) - Adding modificators to class names for all components in app.
  - [vue-styler](https://github.com/mrtone/vue-styler) - Simple, performant styler for vue.
  - [vue-css-modules](https://github.com/fjc0k/vue-css-modules) - Seamless mapping of class names to CSS Modules inside of Vue components.
+ - [vue-simple-bem](https://github.com/mlturner88/vue-simple-bem) - Directive with succint syntax for adding BEM class names to elements.
 
 ### Asset Management
 


### PR DESCRIPTION
I wanted to add a directive I wrote for a large project at work here for others to use. It uses a succinct directive syntax similar to [the new  `v-slot` syntax](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0001-new-slot-syntax.md) for adding/generating BEM class names for elements.