### PR TITLE
add avatio-avatar component

### DIFF
--- a/README.md
+++ b/README.md
@@ -1463,7 +1463,8 @@ Tooltips / popovers
  - [vue-terminal-ui](https://github.com/shershen08/vue-terminal-ui) - 🖥Terminal UI emulator Vue: custom and basic commands
  - [vue-command](https://github.com/ndabAP/vue-command) - A fully working Vue.js terminal emulator
  - [vue-ribbon](https://github.com/P3trur0/vue-ribbon) - Vue component for GitHub ribbons
-
+ - [avatio-avatar](https://github.com/trunda/avatio-avatar) - Vue component for illustrated avatars - used by [Avatio](https://avatio.cool)
+ 
 ### Tabs
 
  - [vue-tabs](https://github.com/cristijora/vue-tabs) - Simple tabs and pills.


### PR DESCRIPTION
Hi there, PR to add [Avatio avatar](https://github.com/trunda/avatio-avatar) component. It's used on [Avatio site](https://avatio.cool) and it's opensource.