### PR TITLE
Add Vuelibs to External Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@
 - [BuiltForVue](https://builtforvue.com) - NPM Mirror of all Vue.js components and packages.
 - [Vue School](https://vueschool.io) - Learn Vue.js from video courses by core members and industry experts
 - [VueDose](https://vuedose.tips). Tips & tricks about the Vue ecosystem, for busy devs.
+- [Vuelibs](https://vuelibs.org). A minimalistic list of Vue.js libraries and components based on the awesome-vue repo.
 
 
 ### Job Portal


### PR DESCRIPTION
Vuelibs.org is a list of Vue.js libraries and components based on the awesome-vue repo.
The source code is also released as open source: https://github.com/ernestii/vuelibs.org

Thank you!