### PR TITLE
Add vue-fixed-header to UI > Miscellaneous

### DIFF
--- a/README.md
+++ b/README.md
@@ -1471,6 +1471,8 @@ Tooltips / popovers
  - [avatio-avatar](https://github.com/trunda/avatio-avatar) - Vue component for illustrated avatars - used by [Avatio](https://avatio.cool)
  - [vue-jazzicon](https://github.com/man15h/vue-jazzicon) - A dead-simple Jazzicon component for Vue.
  - [vue-star-rating](https://github.com/craigh411/vue-star-rating) - A simple, highly customisable star rating component ⭐️ ⭐️ ⭐️
+- [vue-fixed-header](https://github.com/potato4d/vue-fixed-header)
+ - Simple and cross-browser friendly fixed header component for Vue.js written by TypeScript.
 
 ### Tabs
 


### PR DESCRIPTION
A component that can be used as an alternative if `position: sticky` is not available.
I was unsure about the category, so I placed it in Miscellaneous, but if there is a better place please let me know!