### PR TITLE
Adds vue-i18n-extract

### DIFF
--- a/README.md
+++ b/README.md
@@ -2295,6 +2295,7 @@ the amazing Vue.js.
  - [vue-translation-manager](https://github.com/cyon/vue-translation-manager) - Interactively find and translate strings in your Vue.js application. Works well with vue-18n and vuex-i18n.
  - [vue-t9n](https://github.com/Ni55aN/vue-t9n) - Simplest way to translate your applications
  - [vue-simple-inline-translation](https://github.com/alidrus/vue-simple-inline-translation) - A Vue component that simplifies the way text is translated: by translating it inline.
+ - [vue-i18n-extract](https://github.com/pixari/vue-i18n-extract) - Manage vue-i18n localization with static analysis. Make reports about missing and unused i18n entries.
 
 ### Custom Events
 


### PR DESCRIPTION
vue-i18n-extract is built to work with your Vue.js projects using vue-i18n. When run vue-18n-extract analyses your Vue.js source code for any vue-i18n key usages (ex. $t(''), $tc(''), ...) as well as your language files (ex. de_DE.js, en_EN.json, ...), in order to:

 I18NReport keys that are missing in the language files.
 I18NReport unused keys in the language files.