### PR TITLE
Vue simple search dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1192,6 +1192,7 @@ Tooltips / popovers
  - [vue-burger-menu](https://github.com/mbj36/vue-burger-menu) - An off-canvas sidebar Menu component with different CSS animations.
  - [vue-dynamic-dropdown](https://github.com/JonathanDn/vue-dropdown) - A Highly Customizable, easy-to-use elegant dropdown component
  - [vue-navigation-bar](https://github.com/johndatserakis/vue-navigation-bar) - A simple, pretty navbar for your Vue projects.
+ - [vue-simple-search-dropdown](https://github.com/romainsimon/vue-simple-search-dropdown) - A simple searchable input dropdown component with no external dependency
 
 ### Minus Plus Input
 


### PR DESCRIPTION
Added `vue-simple-search-dropdown`, a simple searchable input dropdown component with no external dependency

Link added : [https://github.com/romainsimon/vue-simple-search-dropdown](https://github.com/romainsimon/vue-simple-search-dropdown)