### PR TITLE
Add vvcc-decorators to Typescript category

### DIFF
--- a/README.md
+++ b/README.md
@@ -2252,6 +2252,7 @@ based on [threejs](https://threejs.org/) and [Panolens](https://pchen66.github.i
  - [vue-local-storage-decorator](https://github.com/vip30/vue-local-storage-decorator) - Persist data by using local stoarge in decorator format
  - [vuex-module-decorators](https://github.com/championswimmer/vuex-module-decorators) - Typescript/ES7 Decorators to make Vuex modules a breeze
  - [vuex-class-modules](https://github.com/gertqin/vuex-class-modules) - Introduce a simple type-safe class style syntax for your vuex modules, inspired by vue-class-component.
+ - [vvcc-decorators](https://github.com/jzatt/vvcc-decorators) - Access your Vuex actions, mutations, getters and state in your Vue component.
 
 ### HTTP Requests
 


### PR DESCRIPTION
Adds [VVCC-Decorators](https://github.com/jzatt/vvcc-decorators) to the Typescript category