### PR TITLE
Remove Vue.js Plugin plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -2750,7 +2750,6 @@ Payment utilities.
 
 #### Intellij
 
- - [Vue.js Plugin](https://github.com/postalservice14/vuejs-plugin) - Vue.js features for the Intellij Platform (WebStorm, RubyMine, Intellij, etc).
  - [Vue.js support for WebStorm](https://github.com/JetBrains/intellij-plugins/tree/master/vuejs), IntelliJ IDEA, PhpStorm, PyCharm & RubyMine – official Vue.js support by JetBrains
 
 #### Emacs


### PR DESCRIPTION
The plugin is deprecated since November 2018 in favour of the official Vue.js plugin made by JetBrains.