### PR TITLE
Add updated repo/version of Pomotroid electron app

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,7 +691,7 @@
 - [TimeMark](https://github.com/MarsZone/TimeMark) - A Time manager which will can record your time and some more function will be developed.
 - [Laravel Enso](https://github.com/laravel-enso/enso) - SPA Admin Panel built with Bulma, VueJS and Laravel, packing lots of features out of the box.
 - [Code Notes](https://github.com/lauthieb/code-notes) - A simple code snippet manager for developers built with Electron & Vue.js.
-- [Pomotroid](https://github.com/Splode/pomotroid) - Simple, visually-pleasing and customizable Pomodoro timer.
+- [Pomotroid (Updated!)](https://github.com/karimdaghari/pomotroid) - Simple, visually-pleasing and customizable Pomodoro timer.
 - [XMR Miner](https://github.com/bradoyler/xmr-miner) - Cryptocurrency (XMR) mining app, built with Vue.js and visualized with D3
 - [XMR Paper](https://github.com/bradoyler/xmr-paper) - Monero wallet generator, built with Vue.js
 - [JoyProxy](https://github.com/sh0cked/joy-proxy) - Chrome extension for handling proxy settings

--- a/README.md
+++ b/README.md
@@ -1379,6 +1379,8 @@ Tooltips / popovers
  - [v-playback](https://github.com/TerryZ/v-playback) - A Vue2 plugin to make video play easier.
  - [vue-audio-recorder](https://github.com/grishkovelli/vue-audio-recorder) - Audio recorder for Vue.js. It allows to create, play, download and store records on a server
  - [vue-video-section](https://github.com/johndatserakis/vue-video-section) - A simple video header/section component for Vue. Good for video backgrounds and overlaying content on them.
+ - [vue-video-hero](https://github.com/kdaghari/vue-video-hero) - A responsive video section with content overlay, all with sensible defaults (YouTube only)
+
 
 ### Infinite Scroll
 


### PR DESCRIPTION
This a fork of [Splode/Pomotroid](https://github.com/Splode/pomotroid). The original project has been inactive for over a year so I guess it's safe to assume it's dead. 