### PR TITLE
Adding RSVP Keeper to the Apps/Websites section

### DIFF
--- a/README.md
+++ b/README.md
@@ -998,6 +998,7 @@
   - [AwesomeTechStack](https://awesometechstack.com) - Website Tech Stack Analyzer
   - [massCode](https://github.com/antonreshetov/massCode) - An open source code snippets manager for developers. Build with Electron, Vue and Monaco editor.
   - [ClipLeap](https://www.clipleap.com/) - Platform for posting and sharing moments in long videos.
+  - [RSVP Keeper](https://www.rsvpkeeper.com/) - Online reservations made easy. Get your event up and running in no time. Made with Vue and Go.
 
 ### Interactive Experiences
 


### PR DESCRIPTION
Adding RSVP Keeper to the Apps/Websites section

RSVP Keeper is a full-featured online reservation app built with Vue and Go.

https://www.rsvpkeeper.com/