### PR TITLE
Updated link to vue-material-design-icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1206,7 +1206,7 @@ Tooltips / popovers
 ### Icons
 
  - [vue-awesome](https://github.com/Justineo/vue-awesome) - Font Awesome component for Vue.js, using inline SVG.
- - [vue-material-design-icons](https://gitlab.com/robcresswell/vue-material-design-icons "vue-material-design-icons on GitLab") - A collection of SVG Material Design icons as single file components.
+ - [vue-material-design-icons](https://github.com/robcresswell/vue-material-design-icons "vue-material-design-icons on GitHub") - A collection of SVG Material Design icons as single file components.
  - [vue-icon-font](https://github.com/ganl/vue-icon-font) - A iconfont plugin for Vuejs (support Font-class and Symbol).
  - [vue-ionicons](https://github.com/mazipan/vue-ionicons) - Vue Icon Set Components from Ionic Team.
  - [vue-ico](https://github.com/paulcollett/vue-ico) - Dead easy icons for Vue with drop-in browser support & selective bundling


### PR DESCRIPTION
Updated the link to the vue-material-design-icons from the old GitLab repository to the new GitHub repository.

You can see the GitLab repository points to the new GitHub repository on the project page in [GitLab](https://gitlab.com/robcresswell/vue-material-design-icons). 