### PR TITLE
Add vue-trip-wire

### DIFF
--- a/README.md
+++ b/README.md
@@ -2160,6 +2160,7 @@ composing CSS breakpoint state.
 - [vue-check-view](https://github.com/vtimofeev/vue-check-view) - A plugin that checks if element is in viewport. Fast, small, has no dependencies, live demo.
 - [vue-stickto](https://github.com/JALBAA/vue-stickto) - A vue directive that support multiple DOM nodes stick to top automatically
 - [vue2-scrollspy](https://github.com/ibufu/vue2-scrollspy) - A scrollspy plugin and animated scroll-to.
+- [vue-trip-wire](https://github.com/lorrenrules/vue-trip-wire) - A custom directive for firing functions when an element reaches a designated point in the viewport, with option to import module with globally accessible functions.
 
 *Customize the scroll behavior*
 


### PR DESCRIPTION
Add vue-trip-wire to readme: UI Utilities —> Scroll —> Detect when components enter viewport.