### PR TITLE
Quasar dropped iOS native look support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1926,7 +1926,7 @@ Tooltips / popovers
 
 *Set of components + responsive layout system*
 
- - [quasar-framework](https://github.com/quasarframework/quasar) - Quasar Framework. Build responsive websites, hybrid mobile Apps (that look native on Android and iOS) and Electron apps using same code, with VueJs 2.
+ - [quasar-framework](https://github.com/quasarframework/quasar) - Quasar Framework. Build responsive websites, hybrid mobile Apps and Electron apps using same code, with VueJs 2.
  - [vue-material](https://github.com/vuematerial/vue-material) - Material design for Vue.js.
  - [vuetify](https://github.com/vuetifyjs/vuetify) - Material Component Framework for Vue.js 2.
  - [muse-ui](https://github.com/museui/muse-ui) - Material Component library for Vue.js 2.


### PR DESCRIPTION
... so one of the main selling points is gone, unfortunately:
https://forum.quasar-framework.org/topic/3191/v1-how-to-build-with-ios-theme-t-ios