### PR TITLE
Add Staples Canada to Enterprise Usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -987,6 +987,7 @@
  - [Subtletab - Browser Extension](https://subtletab.com)
  - [web-riimote](https://web-riimote.herokuapp.com) - Turn your smartphone into a 3D controller ([source code](https://github.com/konaraddio/web-riimote))
  - [CSS ColorVars](https://csscolorvars.github.io/) - Interactive tool code generation ([source code](https://github.com/CSSColorVars/csscolorvars))
+
 ### Enterprise Usage
 
  - Alibaba
@@ -1017,6 +1018,7 @@
  - [Cotabox](https://cotabox.com.br)
  - [Aromajoin](https://aromajoin.com) - Develop the finest digital scent products based on the harmony of hardware, software and material technology.
  - [Carrefour](https://www.carrefour.fr)
+ - [Staples Canada](https://www.staples.ca/)
 
 ### A11y
 


### PR DESCRIPTION
Adding [Staples Canada](https://www.staples.ca/) to list of Enterprises.