### PR TITLE
Removed not working link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1909,7 +1909,6 @@ Tooltips / popovers
  - [vue-quill-editor](https://github.com/surmon-china/vue-quill-editor) - Quill editor component for Vue2.
  - [vue-mobiledoc-editor](https://github.com/alidcastano/vue-mobiledoc-editor) - A mobiledoc editor component toolkit for Vuejs.
  - [vue2-medium-editor](https://github.com/FranzSkuffka/vue-medium-editor) - A MediumEditor component for Vue 2.
- - [vue-froala](https://github.com/helpbase/vue-froala) - VueJS wrapper for Froala Editor.
  - [vue-froala-wysiwyg](https://github.com/froala/vue-froala-wysiwyg) - Official VueJS plugin for Froala WYSIWIG HTML Editor.
  - [vue-at](https://github.com/fritx/vue-at) - At.js for Vue.
  - [vue-wysiwyg](https://github.com/chmln/vue-wysiwyg) Lightweight, fast & extensible WYSIWYG editor


### PR DESCRIPTION
It seems repo has been deleted :
https://github.com/helpbase/vue-froala

### `General`
> ✏️ Mark the necessary items without changing the structure of the PR template.

- [x] Pull request template structure not broken

### `Type`

> ℹ️  What types of changes does your code introduce?

> 👉 _Put an `x` in the boxes that apply_

- [x] Fix
- [ ] Feature 

### `Checklist`

> ℹ️  Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](https://github.com/vuejs/awesome-vue/blob/master/.github/contributing.md).

> 👉  _Put an `x` in the boxes that apply._

- [x] Title as described
- [x] Make sure you put things in the right category!
- [x] Always add your items to the end of a list

#### `Open Source`

- [x] The documentation (README) contains a description of the project, illustration of the project with a demo or screenshots and a CONTRIBUTING section
- [x] The documentation is in English.
- [x] The project is active and maintained.
- [x] The project accepts contributions.
- [x] Not a commercial product

#### `Apps/Websites`

- [x] The website is available without errors or ssl certificate problems, and load in a reasonable amount of time.
- [x] The website is using vuejs intensively. It should detect vue with [vue-devtools](https://github.com/vuejs/vue-devtools).
  > If you cannot detect vue with `vue-devtools` due to work at non public pages (e.g. for enterprise website), you can send Pull Request with screenshot that detected it.
- [x] The website is original and not too simple. For that reason, blogs and simple landing pages are rejected.
- [x] A commercial product using Vue, provided that guests could reasonably check out how Vue was used A commercial product using Vue, provided that guests could reasonably check out how Vue was used (i.e. A headless CMS which uses Vue for the Admin/editor Area and offers a free tier).
