### PR TITLE
Argon Dashboard Vue 3, Element Plus & TailwindCSS 3 - A simplate dashboard template with VueJS 3, Element Plus & TailwindCSS 3 - Inspired by Creative Tim

### DIFF
--- a/README.md
+++ b/README.md
@@ -2488,6 +2488,7 @@ _Set of admin template_
 
 - [iView Vue Admin](https://github.com/TonyLuo/iview-vue-admin) - iView Vue Admin / An admin portal template based on iView 2.x [Online Demo](https://tonyluo.github.io/iview-vue-admin)
 - [element Vue Admin](https://github.com/TonyLuo/element-vue-admin) - element Vue Admin / An admin portal template based on Element UI 2.x
+- [Argon Dashboard Vue 3, Element Plus & TailwindCSS 3](https://github.com/ltv/argon-dashboard-vue3) - A simplate dashboard template with VueJS 3, Element Plus & TailwindCSS 3 - Inspired by Creative Tim
 - [vue-element-admin](https://github.com/PanJiaChen/vue-element-admin) - A magical vue admin based on Element UI 2.x [Online Demo](https://panjiachen.github.io/vue-element-admin/#/dashboard)
 - [D2 Admin](https://github.com/d2-projects/d2-admin) - An elegant backstage template build by vue [Online Demo](https://d2admin.fairyever.com)
 - [rest-admin](https://github.com/wxs77577/rest-admin) - Restful Admin Panel Based on Vue and Bootstrap 4 [Online Demo](http://rest-admin.genyii.com)

--- a/README.md
+++ b/README.md
@@ -2505,8 +2505,7 @@ _Set of admin template_
 - [Admin One Vue 3 Tailwind dashboard](https://github.com/justboil/admin-one-vue-tailwind) - Vue.js 3 Tailwind CSS admin template with dark mode.
 - [Mosaic - Vue Admin TailwindCSS template](https://github.com/cruip/vuejs-admin-dashboard-template) - The All-in-one Tailwind CSS Admin Dashboard Template.
 - [vue-admin-box](https://github.com/cmdparkour/vue-admin-box) - The admin template based on vue3 and element-plus. [Live demo](https://cmdparkour.github.io/vue-admin-box/dist/)
-- [Argon Dashboard Vue 3, Element Plus & TailwindCSS 3](https://github.com/ltv/argon-dashboard-vue3) - A simplate dashboard template with VueJS 3, Element Plus & TailwindCSS 3 - Inspired by Creative Tim
-
+- [argon-dashboard-vue3](https://github.com/ltv/argon-dashboard-vue3) - Template, Element Plus & TailwindCSS 3, Vue3.
 #### Server-side rendering
 
 - [Nuxt.js](https://github.com/nuxt/nuxt.js) - Versatile Vue.js Framework.

--- a/README.md
+++ b/README.md
@@ -2488,7 +2488,6 @@ _Set of admin template_
 
 - [iView Vue Admin](https://github.com/TonyLuo/iview-vue-admin) - iView Vue Admin / An admin portal template based on iView 2.x [Online Demo](https://tonyluo.github.io/iview-vue-admin)
 - [element Vue Admin](https://github.com/TonyLuo/element-vue-admin) - element Vue Admin / An admin portal template based on Element UI 2.x
-- [Argon Dashboard Vue 3, Element Plus & TailwindCSS 3](https://github.com/ltv/argon-dashboard-vue3) - A simplate dashboard template with VueJS 3, Element Plus & TailwindCSS 3 - Inspired by Creative Tim
 - [vue-element-admin](https://github.com/PanJiaChen/vue-element-admin) - A magical vue admin based on Element UI 2.x [Online Demo](https://panjiachen.github.io/vue-element-admin/#/dashboard)
 - [D2 Admin](https://github.com/d2-projects/d2-admin) - An elegant backstage template build by vue [Online Demo](https://d2admin.fairyever.com)
 - [rest-admin](https://github.com/wxs77577/rest-admin) - Restful Admin Panel Based on Vue and Bootstrap 4 [Online Demo](http://rest-admin.genyii.com)
@@ -2506,6 +2505,7 @@ _Set of admin template_
 - [Admin One Vue 3 Tailwind dashboard](https://github.com/justboil/admin-one-vue-tailwind) - Vue.js 3 Tailwind CSS admin template with dark mode.
 - [Mosaic - Vue Admin TailwindCSS template](https://github.com/cruip/vuejs-admin-dashboard-template) - The All-in-one Tailwind CSS Admin Dashboard Template.
 - [vue-admin-box](https://github.com/cmdparkour/vue-admin-box) - The admin template based on vue3 and element-plus. [Live demo](https://cmdparkour.github.io/vue-admin-box/dist/)
+- [Argon Dashboard Vue 3, Element Plus & TailwindCSS 3](https://github.com/ltv/argon-dashboard-vue3) - A simplate dashboard template with VueJS 3, Element Plus & TailwindCSS 3 - Inspired by Creative Tim
 
 #### Server-side rendering
 


### PR DESCRIPTION
[Argon Dashboard Vue 3, Element Plus & TailwindCSS 3](https://github.com/ltv/argon-dashboard-vue3) - A simplate dashboard template with VueJS 3, Element Plus & TailwindCSS 3 - Inspired by Creative Tim
https://github.com/ltv/argon-dashboard-vue3

### `General`
> ✏️ Mark the necessary items without changing the structure of the PR template.

- [x] Pull request template structure not broken

### `Type`

> ℹ️  What types of changes does your code introduce?

> 👉 _Put an `x` in the boxes that apply_

- [ ] Fix
- [x] Feature 

### `Checklist`

> ℹ️  Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](https://github.com/vuejs/awesome-vue/blob/master/.github/contributing.md).

> 👉  _Put an `x` in the boxes that apply._

- [x] Title as described
- [x] Make sure you put things in the right category!
- [x] Always add your items to the end of a list

#### `Open Source`

- [x] Link description does not contain a link to an author / third-party resource
- [x] The documentation (README) contains a description of the project, illustration of the project with a demo or screenshots and a CONTRIBUTING section
- [x] The documentation is in English.
- [x] The project is active and maintained.
- [x] The project accepts contributions.
- [x] Not a commercial product

#### `Apps/Websites`

- [x] The website is available without errors or ssl certificate problems, and load in a reasonable amount of time.
- [x] The website is using vuejs intensively. It should detect vue with [vue-devtools](https://github.com/vuejs/vue-devtools).
  > If you cannot detect vue with `vue-devtools` due to work at non public pages (e.g. for enterprise website), you can send Pull Request with screenshot that detected it.
- [ ] The website is original and not too simple. For that reason, blogs and simple landing pages are rejected.
- [ ] A commercial product using Vue, provided that guests could reasonably check out how Vue was used (i.e. A headless CMS which uses Vue for the Admin/editor Area and offers a free tier).
