### PR TITLE
fix: update links for MobX bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -3214,9 +3214,8 @@ _LocalStorage etc._
 
 ##### Mobx
 
-- [movue](https://github.com/nighca/movue) - Mobx integration for Vue.js.
-- [vue-mobx](https://github.com/dwqs/vue-mobx) - Mobx binding for Vuejs 2.x.
-- [mobx-vue-lite](https://github.com/wobsoriano/mobx-vue-lite) - Lightweight Vue 3 bindings for MobX based on Composition API.
+- [mobx-vue-lite](https://github.com/mobxjs/mobx-vue-lite) - Lightweight Vue 3 bindings for MobX based on Composition API.
+- [mobx-vue](https://github.com/mobxjs/mobx-vue) - Vue 2 bindings for MobX.
 
 ##### Pinia
 


### PR DESCRIPTION
### `General`
> ✏️ Mark the necessary items without changing the structure of the PR template.

- [x] Pull request template structure not broken

### `Type`

> ℹ️  What types of changes does your code introduce?

> 👉 _Put an `x` in the boxes that apply_

- [x] Fix
- [ ] Feature 

### `Checklist`

> ℹ️  Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](https://github.com/vuejs/awesome-vue/blob/master/.github/contributing.md).

> 👉  _Put an `x` in the boxes that apply._

- [x] Title as described
- [x] Make sure you put things in the right category!
- [x] Always add your items to the end of a list

#### `Open Source`

- [x] Link description does not contain a link to an author / third-party resource
- [x] The documentation (README) contains a description of the project, illustration of the project with a demo or screenshots and a CONTRIBUTING section
- [x] The documentation is in English.
- [x] The project is active and maintained.
- [x] The project accepts contributions.
- [x] Not a commercial product

#### `Apps/Websites`

- [ ] The website is available without errors or ssl certificate problems, and load in a reasonable amount of time.
- [ ] The website is using vuejs intensively. It should detect vue with [vue-devtools](https://github.com/vuejs/vue-devtools).
  > If you cannot detect vue with `vue-devtools` due to work at non public pages (e.g. for enterprise website), you can send Pull Request with screenshot that detected it.
- [ ] The website is original and not too simple. For that reason, blogs and simple landing pages are rejected.
- [ ] A commercial product using Vue, provided that guests could reasonably check out how Vue was used (i.e. A headless CMS which uses Vue for the Admin/editor Area and offers a free tier).

---

### Details

- Old link for [movue](https://github.com/nighca/movue) (Vue 2 bindings) is removed as it is explicitly deprecated and archived for over 2.5 years in favor of the official [mobx-vue](https://github.com/mobxjs/mobx-vue) (Vue 2 bindings).
- Old link for [vue-mobx](https://github.com/dwqs/vue-mobx) (Vue 2 bindings) is replaced with the official [mobx-vue](https://github.com/mobxjs/mobx-vue) (Vue 2 bindings) as [vue-mobx](https://github.com/dwqs/vue-mobx) hasn't been updated for over 6.5 years.
- Old link for [mobx-vue-lite](https://github.com/wobsoriano/mobx-vue-lite) (Vue 3 bindings) is updated to [mobx-vue-lite](https://github.com/mobxjs/mobx-vue-lite) as the lib is now under the official mobxjs org (but with the same maintainer) and the old link 404s without redirection.
- [mobx-vue-lite](https://github.com/mobxjs/mobx-vue-lite) (Vue 3 bindings) is placed before [mobx-vue](https://github.com/mobxjs/mobx-vue) (Vue 2 bindings) as Vue 2 has reached end-of-life and much less relevant.