### PR TITLE
added to Drag n Drop list, my libary

### DIFF
--- a/README.md
+++ b/README.md
@@ -1084,7 +1084,7 @@ _Overlay / modal / alert / dialog / lightbox / popup_
 
 #### Icons
 
-- [vue-material-design-icons](https://github.com/robcresswell/vue-material-design-icons "vue-material-design-icons on GitHub") - A collection of SVG Material Design icons as single file components.
+- [vue-material-design-icons](https://github.com/robcresswell/vue-material-design-icons 'vue-material-design-icons on GitHub') - A collection of SVG Material Design icons as single file components.
 - [vue-fontawesome](https://github.com/FortAwesome/vue-fontawesome) - Font Awesome 5 Vue component
 - [vue-country-flag](https://github.com/P3trur0/vue-country-flag) - Vue component for country flag icons
 - [vue-fa](https://github.com/Cweili/vue-fa) - Simple FontAwesome 5 Vue.js 2 component.
@@ -1283,6 +1283,7 @@ _Date / datetime / time Picker_
 
 ##### Drag and Drop
 
+- [Vue DnD Kit](https://github.com/zizigy/vue-dnd-kit) - A lightweight, performant drag and drop toolkit for Vue 3 with composable API, keyboard navigation, accessibility support, and advanced customization options. Supports any cases, and touch devices. Inspired by React DnD Kit
 - [vuedraggable-plus](https://github.com/Alfred-Skyblue/vue-draggable-plus) - Vue component allowing drag-and-drop sorting module, support Vue>=v3 or Vue>=2.7. Based on Sortable.js.
 - [vue-draggable-resizable](https://github.com/mauricius/vue-draggable-resizable) - Vue2 component for draggable and resizable elements.
 - [vue-smooth-dnd](https://github.com/kutlugsahin/vue-smooth-dnd) - Vue wrappers of smooth-dnd library. drag and drop, sortable library covering for many cases.
@@ -1726,7 +1727,9 @@ _Render Vue application to HTML on the server and to the DOM in the browser_
 ### Prerendering
 
 - [vue-genesis](https://github.com/fmfe/genesis) - 🔥Micro front end, micro service and lightweight solution based on Vue SSR🔥
+
   <!-- md-parser-end -->
+
   <br/>
   <br/>
   <br/>


### PR DESCRIPTION
# Add Vue DnD Kit to Drag and Drop section

I'd like to add Vue DnD Kit to the Awesome Vue list in the Drag and Drop section.

## About Vue DnD Kit
Vue DnD Kit is a lightweight, performant drag and drop toolkit for Vue 3 with composable API, keyboard navigation, accessibility support, and advanced customization options. It's designed to provide a flexible foundation for building complex drag and drop interfaces while maintaining excellent performance.

## Key features
- Lightweight with minimal bundle size impact
- Composable API based on Vue 3 Composition API
- Full keyboard navigation support (WASD, Space/Enter, Escape)
- Accessibility features for screen readers
- Support for sortable lists, nested drag and drop
- Customizable appearance and behavior
- Support for animations with CSS and JS animation libraries
- TypeScript support

## Links
- GitHub: https://github.com/zizigy/vue-dnd-kit
- Documentation: https://zizigy.github.io/vue-dnd-kit

The library is actively maintained, accepts contributions, and provides comprehensive documentation in English. It fills a gap in the Vue 3 ecosystem for a modern, accessible drag and drop solution built specifically with the Composition API in mind.

I've added it to the end of the "Drag and Drop" section as per the contribution guidelines.

Thank you for considering! <3