### PR TITLE
docs(README.md): adding `vue-skeleton-content-loader` lib on the reference list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1054,6 +1054,7 @@ _Loaders / spinners / progress bars — Let the user know that something is load
 - [vue-loading-overlay](https://github.com/ankurk91/vue-loading-overlay) - Tiny full screen loading indicator
 - [vue-ellipse-progress](https://github.com/setaman/vue-ellipse-progress) - A flexible Vue.js component to create beautiful animated circular progress bars and loaders
 - [vue-default-page](https://github.com/zero-one-code/vue-default-page) - A Vue 3.0 plugin with built-in v-loading, v-skeleton, v-error and v-empty custom directives.
+- [vue-skeleton-content-loader](https://github.com/willmendesneto/vue-skeleton-content-loader) - Lightweight and accessible library to make beautiful, animated loading skeletons that automatically adapt to your Vue app
 
 ##### Progress Bar
 


### PR DESCRIPTION
Adding `vue-skeleton-content-loader` lib on the reference list for loader components to be used in Vue apps

### `General`
> ✏️ Mark the necessary items without changing the structure of the PR template.

- [x] Pull request template structure not broken

### `Type`

> ℹ️  What types of changes does your code introduce?

> 👉 _Put an `x` in the boxes that apply_

- [ ] Fix
- [ ] Feature 

### `Checklist`

> ℹ️  Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](https://github.com/vuejs/awesome-vue/blob/master/.github/contributing.md).

> 👉  _Put an `x` in the boxes that apply._

- [x] Title as described
- [x] Make sure you put things in the right category!
- [x] Always add your items to the end of a list

#### `Open Source`

- [x] Link description does not contain a link to an author / third-party resource
- [x] The documentation (README) contains a description of the project, illustration of the project with a demo or screenshots and a CONTRIBUTING section
- [x] The documentation is in English.
- [x] The project is active and maintained.
- [x] The project accepts contributions.
- [x] Not a commercial product

#### `Apps/Websites`

- [ ] The website is available without errors or ssl certificate problems, and load in a reasonable amount of time.
- [ ] The website is using vuejs intensively. It should detect vue with [vue-devtools](https://github.com/vuejs/vue-devtools).
  > If you cannot detect vue with `vue-devtools` due to work at non public pages (e.g. for enterprise website), you can send Pull Request with screenshot that detected it.
- [ ] The website is original and not too simple. For that reason, blogs and simple landing pages are rejected.
- [ ] A commercial product using Vue, provided that guests could reasonably check out how Vue was used (i.e. A headless CMS which uses Vue for the Admin/editor Area and offers a free tier).
