### PR TITLE
Add oaysus - visual page builder for Vue components

### DIFF
--- a/README.md
+++ b/README.md
@@ -1752,6 +1752,7 @@ _Scaffold / boilerplate / seed / starter kits / stack ensemble / Yeoman generato
 - [vue-x-platforms](https://github.com/NativeScript/vue-x-platforms) - Vue running on Web, iOS, Android and Vision Pro.
 - [mevn-boilerplate](https://github.com/mustafacagri/mevn-boilerplate) - ⭐️ the most comprehensive mevn stack boilerplate. ⭐️ mongodb - express - vue 3 (admin dashboard) - nodejs - nuxt 3 (client) boilerplate (pinia, tiptap, slug, vuetify and vuexy and more...) 🎉
 - [monorepo-template](https://github.com/Nagell/monorepo_template) - 🗂️ Vue 3 monorepo template with pnpm, Nx, Vite, Tailwind CSS, Storybook, TypeScript, and ready-to-use shared libraries.
+- [oaysus](https://github.com/oaysus/cli) - Visual page builder for developer-built Vue components. Push components with one CLI command, let marketing create pages visually.
 
 #### Universal
 


### PR DESCRIPTION
## Summary

Adding [oaysus](https://github.com/oaysus/cli), a visual page builder that allows developers to build Vue components and push them with a single CLI command, enabling marketing teams to create pages visually.

## Checklist

- [x] Title as described
- [ ] - [x] Make sure you put things in the right category!
- [ ] - [x] Always add your items to the end of a list
#### `Open Source`

- [x] Link description does not contain a link to an author / third-party resource
- [ ] - [x] The documentation (README) contains a description of the project, illustration of the project with a demo or screenshots and a CONTRIBUTING section
- [ ] - [x] The documentation is in English.
- [ ] - [x] The project is active and maintained.
- [ ] - [x] The project accepts contributions.
- [ ] - [x] Not a commercial product