### PR TITLE
Add Heroshot to Dev Tools > Docs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1707,6 +1707,7 @@ _Create documentation_
 - [vue-styleguidist](https://github.com/vue-styleguidist/vue-styleguidist) - A style guide generator for Vue components with a living style guide.
 - [vuese](https://github.com/vuese/vuese) - One-stop solution for vue component documentation.
 - [Vue Cheatsheet](https://vue-cheatsheet.themeselection.com/) - The only Vue cheatsheet you will ever need
+- [Heroshot](https://github.com/omachala/heroshot) - Automate documentation screenshots with Vue component integration and theme-aware output.
 
 #### Test
 


### PR DESCRIPTION
Hi! I'd like to add [Heroshot](https://github.com/omachala/heroshot) to the Dev Tools > Docs section.

**Heroshot** is an open-source CLI tool for automating documentation screenshots with a dedicated Vue component integration (`heroshot/vue`).

Features:
- Vue component (`<Heroshot>`) for marking screenshot regions
- Theme-aware captures (light/dark mode)
- Config-based workflow - define screenshots once, update forever
- Works with VitePress, VuePress, and custom Vue apps

It fits well alongside vue-styleguidist and vuese as it helps create visual documentation for Vue projects.

Thank you for maintaining this awesome resource!