### PR TITLE
Add BoldKit - Neubrutalism Vue 3 component library

### DIFF
--- a/README.md
+++ b/README.md
@@ -844,6 +844,7 @@ _Set of components + responsive layout system_
 - [Prefect Design](https://prefect-design.netlify.app/) - Component library using Vue 3, Typescript & Tailwind.
 - [Stellar UI](https://github.com/ManukMinasyan/stellar-ui) - Fully styled and customizable components for Vue 3.
 - [Shadcn UI](https://github.com/radix-vue/shadcn-vue) - An unofficial, community-led Vue port of [shadcn/ui](https://github.com/shadcn-ui/ui) (re-usable components built with [Radix Vue](https://github.com/radix-vue/radix-vue) and [Tailwind CSS](https://github.com/tailwindlabs/tailwindcss)).
+- [BoldKit](https://github.com/ANIBIT14/boldkit) - A neubrutalism-styled Vue 3 component library with 45+ components, 35 SVG shapes, and charts. Built on Reka UI and compatible with shadcn-vue CLI.
 - [Inspira UI](https://inspira-ui.com/) - Open Source components to build stunning animated interfaces effortlessly using Vue, Nuxt and Tailwind CSS.
 - [flowbite-vue](https://github.com/themesberg/flowbite-vue) - Vue component library based on Tailwind CSS
 - [Maz-UI](https://github.com/LouisMazel/maz-ui) - Lightweight and efficient library for Vue 3 & Nuxt 3 & 4 with 50+ components, theming, i18n and useful plugins and composables.


### PR DESCRIPTION
## Add BoldKit

[BoldKit](https://boldkit.dev) is a neubrutalism-styled Vue 3 component library featuring:

- **45+ components** built with Vue 3 Composition API
- **35 SVG shapes** for decorative elements
- **16 chart types** powered by vue-echarts
- Built on **Reka UI** (Vue port of Radix UI)
- Compatible with **shadcn-vue CLI**
- Full **TypeScript** support
- **Dark mode** support

### Links
- Website: https://boldkit.dev
- GitHub: https://github.com/ANIBIT14/boldkit
- Documentation: https://boldkit.dev/docs

### Installation
```bash
npx shadcn-vue@latest add https://boldkit.dev/r/vue/button.json
```

The library provides a unique neubrutalism design aesthetic with thick borders, hard shadows, and high-contrast colors.