### PR TITLE
Update BoldKit entry to include Nuxt support

### DIFF
--- a/README.md
+++ b/README.md
@@ -844,7 +844,7 @@ _Set of components + responsive layout system_
 - [Prefect Design](https://prefect-design.netlify.app/) - Component library using Vue 3, Typescript & Tailwind.
 - [Stellar UI](https://github.com/ManukMinasyan/stellar-ui) - Fully styled and customizable components for Vue 3.
 - [Shadcn UI](https://github.com/radix-vue/shadcn-vue) - An unofficial, community-led Vue port of [shadcn/ui](https://github.com/shadcn-ui/ui) (re-usable components built with [Radix Vue](https://github.com/radix-vue/radix-vue) and [Tailwind CSS](https://github.com/tailwindlabs/tailwindcss)).
-- [BoldKit](https://github.com/ANIBIT14/boldkit) - A neubrutalism-styled Vue 3 component library with 45+ components, 35 SVG shapes, and charts. Built on Reka UI and compatible with shadcn-vue CLI.
+- [BoldKit](https://github.com/ANIBIT14/boldkit) - A neubrutalism-styled Vue 3 & Nuxt component library with 45+ components, 35 SVG shapes, and charts. Built on Reka UI and compatible with shadcn-vue CLI.
 - [Inspira UI](https://inspira-ui.com/) - Open Source components to build stunning animated interfaces effortlessly using Vue, Nuxt and Tailwind CSS.
 - [flowbite-vue](https://github.com/themesberg/flowbite-vue) - Vue component library based on Tailwind CSS
 - [Maz-UI](https://github.com/LouisMazel/maz-ui) - Lightweight and efficient library for Vue 3 & Nuxt 3 & 4 with 50+ components, theming, i18n and useful plugins and composables.


### PR DESCRIPTION
## Update BoldKit Entry

Updates the BoldKit description to reflect newly added Nuxt support.

### Change
- Before: "A neubrutalism-styled Vue 3 component library..."
- After: "A neubrutalism-styled Vue 3 & Nuxt component library..."

### Why
BoldKit now officially supports Nuxt with:
- Full SSR compatibility via shadcn-nuxt module
- Documented ClientOnly wrapper requirements for browser-dependent components
- Installation guide for Nuxt projects

See the [Nuxt installation guide](https://boldkit.dev/docs/installation#nuxt-installation) for details.