### PR TITLE
Remove Vue 2 only entries from Components & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1572,7 +1572,6 @@ _Integrate with services or other frameworks_
 
 _Inspecting & debugging_
 
-- [devtools](https://github.com/vuejs/devtools) - Chrome devtools extension for debugging Vue.js applications.
 - [vite-plugin-vue-inspector](https://github.com/webfansplz/vite-plugin-vue-inspector) - jump to editor source code while click the element of browser automatically.
 - [vue-flow-vis](https://github.com/MiloradFilipovic/vue-flow-vis) - real-time monitoring of component renders and reactive dependency tracking
 


### PR DESCRIPTION
## Summary

Remove 14 entries from Components & Libraries that only support Vue 2 with no Vue 3 migration. Each repo was individually verified via GitHub API and README inspection.

Entries that appeared Vue 2 only based on their awesome-vue description but have actually migrated to Vue 3 (e.g. v-tooltip, v-dialogs, vue-draggable-resizable, vue-cropper) were intentionally kept.

### Removed entries

| Entry | Stars | Reason |
|-------|-------|--------|
| element-ui | 54,203 | Vue 2 only, superseded by Element Plus (already listed) |
| vux | 17,527 | Vue 2 only mobile UI |
| vue-element-admin | 90,281 | Built on Element UI 2.x, Vue 2 only |
| D2 Admin | 12,666 | Vue 2 only admin template |
| Vitify Admin | 162 | Vue 2.7 + Vuetify 2 |
| Vue-Access-Control | 1,074 | Vue 2 only |
| vue-easytable | 3,801 | Vue 2 only |
| Vue Pivottable | 149 | Vue 2 port |
| vue-easy-toast | 119 | Vue 2 only |
| vue2-leaflet | 1,962 | Vue 2 only |
| Vue Datamaps | 20 | Vue 2 port |
| vue-goodshare | 448 | Vue 2 only |
| vue-signature | 204 | Vue 2 only (Vue 3 version is a separate package) |
| vue-option-events | 5 | Bridges Vue 1 events to Vue 2 |

Relates to #4138, #4323