### PR TITLE
Add vue-superselect to Components > Form > Select

### DIFF
--- a/README.md
+++ b/README.md
@@ -1205,6 +1205,7 @@ _Date / datetime / time Picker_
 - [vue-select-sides](https://github.com/juliorosseti/vue-select-sides) - A component for Vue.js to select double-sided data (2-sides).
 - [@vueform/multiselect](https://github.com/vueform/multiselect) - Vue 3 multiselect component with single select, multiselect and tagging options.
 - [vue3-select-component](https://github.com/TotomInc/vue3-select-component) - Vue 3 Select Component, single & multi-select, best-in-class DX support with TypeScript end-to-end typesafe, easy styling, slots and more ~4.4KB
+- [vue-superselect](https://github.com/nemanjamalesija/vue-superselect) - Headless, accessible, TypeScript-first select/combobox for Vue 3 with dual compound component and composable APIs.
 
 ##### Drag and Drop
 


### PR DESCRIPTION
### What kind of change does this PR introduce?

Feature

### Is there an existing issue for this?

No

### Description

Adds [vue-superselect](https://github.com/nemanjamalesija/vue-superselect) to the Components > Form > Select section.

vue-superselect is a headless, accessible, TypeScript-first select/combobox component for Vue 3. It provides a dual API (compound components and a `useSelect()` composable), ships zero CSS, follows the WAI-ARIA combobox pattern, and supports single select, multi-select, filtering, keyboard navigation, and optional Floating UI positioning.

### Checklist

- [x] Entry placed at end of Components > Form > Select list
- [x] Link points to GitHub repo (not docs or npm)
- [x] Description has no links to author or third-party resources
- [x] README has project description, demo/screenshots, and CONTRIBUTING section
- [x] Documentation is in English
- [x] Project is active and maintained
- [x] Project accepts contributions (CONTRIBUTING.md exists)
- [x] Not a commercial product