### PR TITLE
Add JARVIS - Self-hosted AI assistant platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center">
+Resource from plugin:github:github at repo://vuejs/awesome-vue/sha/14fa265df1bd0a3d78fca341a9739a42bf6cd95d/contents/README.md] <p align="center">
   <br>
   <img width="400" src="./assets/logo.svg" alt="logo of vue-awesome repository">
   <br>
@@ -569,6 +569,7 @@ These projects are exceptionally high quality, have a proven trackrecord, and ar
 - [fylepad](https://github.com/imrofayel/fylepad) - a notepad with powerful rich-text editing, built with Vue.
 - [fresfolio](https://github.com/dkioroglou/fresfolio) - a browser-based note-taking app for managing personal and research projects. The app uses Flask as backend and Vue.js as frontend leveraging the Quasar framework for UI components and responsive design.
 
+- [JARVIS](https://github.com/hyhmrright/JARVIS) - Self-hosted AI assistant platform with Vue 3 frontend, Pinia state management, TypeScript, and real-time SSE streaming chat. FastAPI backend with LangGraph ReAct agents, RAG knowledge base, multi-LLM support (DeepSeek/OpenAI/Anthropic), and plugin SDK.
 ### Commercial Products
 
 - [Wijmo](https://wijmo.com/products/wijmo-5/) - A collection of UI controls with VueJS support.


### PR DESCRIPTION
I'm adding JARVIS to the Open Source Projects section.

JARVIS is an open-source, self-hosted AI assistant platform that uses Vue 3 as its frontend:

- **Vue 3** frontend with TypeScript, Pinia state management, vue-i18n (6 languages), and Vue Router with auth guards
- **Real-time SSE streaming** chat using native `fetch` + `ReadableStream`
- **Axios instance** with request/response interceptors for JWT auth and auto-logout
- **Full-stack**: FastAPI backend with LangGraph ReAct agents, RAG knowledge base (Qdrant), multi-LLM support (DeepSeek/OpenAI/Anthropic), plugin SDK, and Docker Compose one-command deployment

Project: https://github.com/hyhmrright/JARVIS
License: MIT

Please let me know if this entry needs any adjustments.