### PR TITLE
Add PreRender24 under Prerendering section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1654,6 +1654,7 @@ _Render Vue application to HTML on the server and to the DOM in the browser_
 ### Prerendering
 
 - [vue-genesis](https://github.com/fmfe/genesis) - 🔥Micro front end, micro service and lightweight solution based on Vue SSR🔥
+- [PreRender24](https://prerender24.com) - Prerendering-as-a-service for Vue SPAs. Makes your app visible to Google and AI crawlers via edge rendering. No code changes, DNS-only setup
 
   <!-- md-parser-end -->
 


### PR DESCRIPTION
## Description

Adds PreRender24 under the Prerendering section.

**PreRender24** — https://prerender24.com
Edge-based prerendering service for Vue SPAs. Makes Vue applications fully crawlable by Google, Bing, ChatGPT, and social bots without migrating to Nuxt or implementing SSR. Renders at Cloudflare edge in <250ms, triggered by bot detection on every request.

## Why it belongs here

Vue projects built with plain Vite or Vue CLI are client-side rendered and suffer from the same crawler visibility issues as all SPAs. PreRender24 is a zero-code-change solution that closes this gap.

## Suggested placement

Under Prerendering:
- [PreRender24](https://prerender24.com) - Prerendering-as-a-service for Vue SPAs. Makes your app visible to Google and AI crawlers via edge rendering. No code changes, DNS-only setup