### PR TITLE
add @rollgate/sdk-vue to Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1559,6 +1559,7 @@ _Integrate with services or other frameworks_
 - [vue-postgrest](https://github.com/technowledgy/vue-postgrest) - Vue.js integration for postgREST: flexible, powerful and easy to use.
 - [vue-tweet](https://github.com/DannyFeliz/vue-tweet) - Vue 3 component that let you embed tweets in your App by only giving the tweet id
 - [vue-tg](https://github.com/deptyped/vue-telegram) - Telegram Web Apps integration for Vue 3.
+- [@rollgate/sdk-vue](https://github.com/rollgate/sdks/tree/main/packages/sdk-vue) - Vue 3 feature flag SDK with composables, gradual rollouts, A/B testing and real-time updates. Backend: [Rollgate](https://rollgate.io)
 
 #### Vue CLI Plugins
 


### PR DESCRIPTION
Adds [@rollgate/sdk-vue](https://github.com/rollgate/sdks/tree/main/packages/sdk-vue) to the Integrations section.

Rollgate Vue SDK is a Vue 3 feature flag client with composables (`useFlag`, `useRollgate`), gradual rollouts, user targeting, A/B testing, and real-time updates via SSE. It's part of an open-source SDK family covering 13 platforms.

- Package: `@rollgate/sdk-vue` on npm
- Repo: https://github.com/rollgate/sdks
- Backend: https://rollgate.io (free tier: 500K requests/month)