### PR TITLE
Add lucide-motion-vue to SVG section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1406,6 +1406,7 @@ _Move a DOM node to a target DOM node_
 
 - [vue-svgicon](https://github.com/MMF-FE/vue-svgicon) - A tool to create svg icon components. (vue 2.x).
 - [vue-inline-svg](https://github.com/shrpne/vue-inline-svg) - Vue component loads an SVG source dynamically and inline `<svg>` so you can manipulate the style of it with CSS or JS. (vue 2.x, vue 3.x)
+- [lucide-motion-vue](https://github.com/respeak-io/lucide-motion-vue) - 516 animated Lucide icons for Vue 3 with ergonomic hover/tap/viewport triggers and a composable `<AnimateIcon>` wrapper. Tree-shakable, one chunk per icon, TypeScript-first. (vue 3.x)
 
 #### Miscellaneous
 


### PR DESCRIPTION
### `General`

- [x] Pull request template structure not broken

### `Type`

- [x] Feature

### `Checklist`

- [x] Title as described
- [x] Make sure you put things in the right category!
- [x] Always add your items to the end of a list

#### `Open Source`

- [x] Link description does not contain a link to an author / third-party resource
- [x] The documentation (README) contains a description of the project, illustration of the project with a demo or screenshots and a CONTRIBUTING section
- [x] The documentation is in English.
- [x] The project is active and maintained.
- [x] The project accepts contributions.
- [x] Not a commercial product

---

Adding **[@respeak/lucide-motion-vue](https://github.com/respeak-io/lucide-motion-vue)** — a Vue 3 port of the animate-ui icon variants and pqoqubbw/icons, built on Motion for Vue. 516 Lucide icons with `animateOnHover`, `animateOnTap`, `animateOnView` triggers, or a composable `<AnimateIcon>` wrapper that turns any element into the trigger. Tree-shakable (one chunk per icon), TypeScript-first, MIT.

Live playground + docs: https://respeak-io.github.io/lucide-motion-vue