### PR TITLE
Add Berry free Vuetify dashboard template to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -897,6 +897,7 @@ _Set of admin template_
 - [soybean-admin](https://github.com/soybeanjs/soybean-admin/blob/main/README.en_US.md) - A clean, elegant, beautiful and powerful admin template, based on Vue3, Vite5, TypeScript, Pinia, NaiveUI and UnoCSS.
 - [AirPower4T](https://github.com/AirPowerTeam/AirPower4T) - A development library based on Vue3, TypeScript, Element Plus, Vite which provides lots of Backend-Platform features such as `OOP` `Decoration` to make your development more efficient.
 - [YummyAdmin](https://github.com/doroudi/YummyAdmin) - 📈 Free Vue Admin Panel based on Naive UI and TailwindCSS. fairly completed with beautiful design, RTL support, and multilingual. (MSW, Pinia, TS, UnoCss, Vite)
+- [Berry free Vue Vuetify dashboard template](https://github.com/codedthemes/berry-free-vuetify-vuejs-admin-template) - A free Vuetify admin dashboard template built with Vue
 
 #### Server-side rendering
 


### PR DESCRIPTION
Added a new Vue Vuetify dashboard template to the README.

### `General`
> ✏️ Mark the necessary items without changing the structure of the PR template.

- [ ] Pull request template structure not broken

### `Type`

> ℹ️  What types of changes does your code introduce?

> 👉 _Put an `x` in the boxes that apply_

- [ ] Fix
- [ ] Feature 

### `Checklist`

> ℹ️  Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](https://github.com/vuejs/awesome-vue/blob/master/.github/contributing.md).

> 👉  _Put an `x` in the boxes that apply._

- [ ] Title as described
- [ ] Make sure you put things in the right category!
- [ ] Always add your items to the end of a list

#### `Open Source`

- [ ] Link description does not contain a link to an author / third-party resource
- [ ] The documentation (README) contains a description of the project, illustration of the project with a demo or screenshots and a CONTRIBUTING section
- [ ] The documentation is in English.
- [ ] The project is active and maintained.
- [ ] The project accepts contributions.
- [ ] Not a commercial product

#### `Apps/Websites`

- [ ] The website is available without errors or ssl certificate problems, and load in a reasonable amount of time.
- [ ] The website is using vuejs intensively. It should detect vue with [vue-devtools](https://github.com/vuejs/vue-devtools).
  > If you cannot detect vue with `vue-devtools` due to work at non public pages (e.g. for enterprise website), you can send Pull Request with screenshot that detected it.
- [ ] The website is original and not too simple. For that reason, blogs and simple landing pages are rejected.
- [ ] A commercial product using Vue, provided that guests could reasonably check out how Vue was used (i.e. A headless CMS which uses Vue for the Admin/editor Area and offers a free tier).
