### PR TITLE
Add validup to Validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1339,6 +1339,7 @@ _Handling of user events (scroll, click, key strike, ...)_
 - [regle](https://github.com/victorgarciaesgi/regle) - ✅ Headless form validation library for Vue.js.
 - [validation-composable](https://github.com/nexxtmove/validation-composable) - ✅ Lightweight validation for Vue — just 40 lines of code.
 - [vue-uform](https://github.com/tu6ge/vue-uform) - an component-first, unstyled, flexible form validation library for Vue 3
+- [validup](https://github.com/tada5hi/validup) - Composable, path-based validation with a Vue 3 composable (`@validup/vue`) for reactive forms, groups, and structured issues.
 
 #### Resize
 


### PR DESCRIPTION
Adds [validup](https://github.com/tada5hi/validup) to **Components & Libraries → UI Utilities → Form → Validation**.

validup is a composable, path-based validation library for TypeScript. Its `@validup/vue` package provides a Vue 3 composable for reactive client-side forms with groups, optional handling, and structured issues, and it bridges to Zod, Standard Schema, and validator.js.

- Docs: https://validup.tada5hi.net
- npm: https://www.npmjs.com/package/@validup/vue
- License: Apache-2.0