### PR TITLE
Add Simple IoT — open-source IoT platform with Vue 3 admin SPA

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,6 +571,7 @@ These projects are exceptionally high quality, have a proven trackrecord, and ar
 - [fresfolio](https://github.com/dkioroglou/fresfolio) - a browser-based note-taking app for managing personal and research projects. The app uses Flask as backend and Vue.js as frontend leveraging the Quasar framework for UI components and responsive design.
 
 - [JARVIS](https://github.com/hyhmrright/JARVIS) - Self-hosted AI assistant platform with Vue 3 frontend, Pinia state management, TypeScript, and real-time SSE streaming chat. FastAPI backend with LangGraph ReAct agents, RAG knowledge base, multi-LLM support (DeepSeek/OpenAI/Anthropic), and plugin SDK.
+- [Simple IoT](https://github.com/dingdaoyi/simple-iot) - Single-binary self-hosted IoT platform with a Vue 3 + Element Plus admin SPA. Visual drag-and-drop rule engine, real-time device dashboard with ECharts, hot-loaded protocol scripts, MQTT broker built-in. Spring Boot 4 backend; lightweight alternative to ThingsBoard CE.
 ### Commercial Products
 
 - [Wijmo](https://wijmo.com/products/wijmo-5/) - A collection of UI controls with VueJS support.


### PR DESCRIPTION
Adds [Simple IoT](https://github.com/dingdaoyi/simple-iot) under **Projects Using Vue.js → Open Source**.\n\nSingle-binary, self-hosted IoT platform whose entire admin SPA is built with **Vue 3 + Element Plus + Pinia + Vite**:\n- Visual drag-and-drop rule-engine canvas\n- Real-time device dashboard powered by ECharts\n- Hot-loaded protocol scripts (Java / JS / Groovy / Lua)\n- Full dark-mode design system\n- Spring Boot 4 backend, MQTT broker built in\n\nLive demo: http://122.51.129.91 — Docs: https://dingdaoyi.github.io/simple-iot/\n\nEntry placed at the end of the *Open Source* list, before *Commercial Products*. Description follows existing format (`- [Name](url) - description.`).