### PR TITLE
Add sketch-to-vue - AI Skill for Sketch MeaXure/MasterGo → Vue conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1662,6 +1662,7 @@ _Render Vue application to HTML on the server and to the DOM in the browser_
 - [Vutron](https://github.com/jooy2/vutron) - Quick start templates for Vite + Electron + Vue 3 + Vuetify + TypeScript.
 - [electron-vite-vue](https://github.com/electron-vite/electron-vite-vue) - Really simple Electron + Vite + Vue boilerplate.
 - [MōBrowser](https://teamdev.com/mobrowser) - A framework for building desktop apps with web technologies. Templates and plumbing for Vite + Vue + Quasar are included.
+- [sketch-to-vue](https://github.com/chenboxun87/sketch-to-vue) - AI Skill for Claude Code & Cursor that converts Sketch MeaXure / MasterGo design exports into pixel-perfect Vue 2/3 components. Specialized for dashboard/cockpit/big-screen pages: deterministic asset resolution, ECharts auto-detection, Scene Graph analysis, and full consumption audit.
 
 ### Prerendering
 


### PR DESCRIPTION
## What is this?

[sketch-to-vue](https://github.com/chenboxun87/sketch-to-vue) is an AI Skill for **Claude Code** and **Cursor** that converts Sketch MeaXure annotation exports (and MasterGo export packages) into pixel-perfect Vue 2 / Vue 3 components.

## Why does it belong in awesome-vue?

- Fills a gap that no existing entry covers: **design tool export → runnable Vue code**
- Supports both **Vue 2 and Vue 3** (auto-detected from package.json)
- Deterministic (no visual guessing / no hallucination) — all assets resolved from JSON/HTML source data
- 30+ automation scripts: element extraction, ECharts zone detection, asset consumption audit, Scene Graph analysis
- Active maintenance, full test suite (
ode test-all.mjs)

## Category

Added under ### Scaffold as a code-generation / design-to-code tool.

## Checklist

- [x] The repo link is correct: https://github.com/chenboxun87/sketch-to-vue
- [x] Description is concise and accurate
- [x] Added at the end of the Scaffold section
- [x] No duplicate entry