### PR TITLE
Update shadcn-vue links, add Reka UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -837,7 +837,8 @@ _Set of components + responsive layout system_
 - [Vuersatile Components](https://www.andres-brugarolas.com/vuersatile-components/) - A Vue 3 component library, with form self-validation and an SCSS framework integrated.
 - [Prefect Design](https://prefect-design.netlify.app/) - Component library using Vue 3, Typescript & Tailwind.
 - [Stellar UI](https://github.com/ManukMinasyan/stellar-ui) - Fully styled and customizable components for Vue 3.
-- [Shadcn UI](https://github.com/radix-vue/shadcn-vue) - An unofficial, community-led Vue port of [shadcn/ui](https://github.com/shadcn-ui/ui) (re-usable components built with [Radix Vue](https://github.com/radix-vue/radix-vue) and [Tailwind CSS](https://github.com/tailwindlabs/tailwindcss)).
+- [Reka UI](https://github.com/unovue/reka-ui) - An open-source library of unstyled, accessible UI primitives for building high-quality design systems and web apps in Vue 3 (formerly Radix Vue).
+- [shadcn-vue](https://github.com/unovue/shadcn-vue) - An unofficial, community-led Vue port of [shadcn/ui](https://github.com/shadcn-ui/ui) (re-usable components built with Reka UI and Tailwind CSS).
 - [BoldKit](https://boldkit.dev) - A neubrutalism component library for Vue 3 & Nuxt with 55+ components, 10 chart types, 64 SVG shapes, and 17 animated ASCII shapes. Built on Reka UI, compatible with shadcn-vue CLI.
 - [Inspira UI](https://inspira-ui.com/) - Open Source components to build stunning animated interfaces effortlessly using Vue, Nuxt and Tailwind CSS.
 - [flowbite-vue](https://github.com/themesberg/flowbite-vue) - Vue component library based on Tailwind CSS


### PR DESCRIPTION
## What

- Update the **shadcn-vue** entry to its current location: `radix-vue/shadcn-vue` → `unovue/shadcn-vue` (the old URL 301-redirects).
- Rename the label `Shadcn UI` → `shadcn-vue` to match the actual repo/package name and disambiguate from the original React [shadcn/ui](https://github.com/shadcn-ui/ui).
- Add **Reka UI** (formerly Radix Vue) as its own entry — the headless/accessible primitives library that shadcn-vue and BoldKit are built on. `radix-vue/radix-vue` was renamed to `unovue/reka-ui`.
- Drop the now-redundant inline links to Reka UI (now has its own entry) and Tailwind CSS (external, non-Vue) from the shadcn-vue description.