### PR TITLE
Add vue-browser-geolocation (Vue 3, promise-based Geolocation API)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2063,6 +2063,7 @@ composing CSS breakpoint state.
  - [vue-detached-scrollbar](https://github.com/ozangulle/vue-detached-scrollbar) - A simple scrollbar that can be detached from the container it is scrolling.
  - [vuescroll](https://github.com/YvesCoding/vuescroll) - A scrolling plugin based on Vue.js for uniforming the scrolling in PC and mobile.
  - [vue-simplebar](https://github.com/hfalucas/vue-simplebar) - Vue.js wrapper for simplebar plugin.
+ - [smooth-vuebar](https://github.com/scaccogatto/smooth-vuebar) - Vue directive wrapper for smooth-scrollbar
 
 *Detect when components enter viewport*
 

--- a/README.md
+++ b/README.md
@@ -2485,6 +2485,7 @@ the amazing Vue.js.
 - [vue-async-operations](https://github.com/devstark-com/vue-async-operations) - Managing async operations statuses in your Vue components
 - [vue-direction](https://github.com/shwilliam/vue-direction) - 👋 Direction aware hover in Vuejs
 - [vue-unique-id](https://github.com/berniegp/vue-unique-id) - Generates unique component ids and component-scoped HTML ids.
+- [vue-browser-geolocation](https://github.com/scaccogatto/vue-browser-geolocation) - Promise-based Vue.js geolocation wrapper for the browser's Geolocation API.
 
 ### Web Workers
 - [vue-worker](https://github.com/israelss/vue-worker) - A Vue.js plugin to use webworkers in a simply way.


### PR DESCRIPTION
## What's added

- **[vue-browser-geolocation](https://github.com/scaccogatto/vue-browser-geolocation)** — Promise-based Vue.js geolocation wrapper for the browser's Geolocation API.
  - 85 stars
  - Vue 3 ready, actively maintained
  - Placed in **Utilities > Miscellaneous** (end of list, per CONTRIBUTING)

## Notes

Checked that `vue-waypoint` and `vue-viewports` (same author) are already listed in the README. Only `vue-browser-geolocation` was missing.