### PR TITLE
Add @stitchapi/vue to HTTP Requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1462,6 +1462,7 @@ _Retrieve data over HTTP_
 - [swrv](https://github.com/Kong/swrv) - Stale-while-revalidate data fetching for Vue.
 - [vue-vroom](https://github.com/frederikbache/vue-vroom) - A plugin for REST APIs, that lets you quickly generate type safe stores and a mock API with minimal config.
 - [tanstack-query](https://github.com/tanstack/query) - Powerful asynchronous state management.
+- [@stitchapi/vue](https://github.com/rejifald/StitchAPI/tree/main/packages/vue) - Streaming-first StitchAPI bindings: typed, validated `useStitch` / `useStitchStream` composables that re-render as response deltas arrive.
 
 #### i18n
 


### PR DESCRIPTION
Adds `@stitchapi/vue` to **Utilities → HTTP Requests** (appended to the end of the list, per the contributing guide).

Vue 3 bindings for StitchAPI — reactive `useStitch` / `useStitchStream` composables. Unlike a plain request/response client it's streaming-first: `useStitchStream` re-renders as each response delta arrives (SSE / stream surfaces), and calls stay typed and runtime-validated. An optional TanStack Query adapter is included.

- Package: https://github.com/rejifald/StitchAPI/tree/main/packages/vue
- npm: https://www.npmjs.com/package/@stitchapi/vue

> Note on the `Open Source` checklist below: this is a library entry under _Utilities_, not a showcase under _Projects using Vuejs_. The README has a description and runnable usage examples, but no dedicated **CONTRIBUTING** section yet, so I've left that one box unchecked rather than claim it. Happy to add one if it's required for inclusion.

### `General`
> ✏️ Mark the necessary items without changing the structure of the PR template.

- [x] Pull request template structure not broken

### `Type`

> ℹ️  What types of changes does your code introduce?

> 👉 _Put an `x` in the boxes that apply_

- [ ] Fix
- [x] Feature

### `Checklist`

> ℹ️  Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](https://github.com/vuejs/awesome-vue/blob/master/.github/contributing.md).

> 👉  _Put an `x` in the boxes that apply._

- [x] Title as described
- [x] Make sure you put things in the right category!
- [x] Always add your items to the end of a list

#### `Open Source`

- [x] Link description does not contain a link to an author / third-party resource
- [ ] The documentation (README) contains a description of the project, illustration of the project with a demo or screenshots and a CONTRIBUTING section
- [x] The documentation is in English.
- [x] The project is active and maintained.
- [x] The project accepts contributions.
- [x] Not a commercial product
